### PR TITLE
feat: add util module with bit manipulation and hex encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 Cargo.lock
+.idea/
+.claude/

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,6 +6,8 @@ use std::fmt;
 pub enum BcError {
     /// An argument passed to a function was invalid.
     InvalidArgument { param: Option<String>, msg: String },
+    /// An I/O error occurred, with an optional source and a message.
+    IoError { source: Option<std::io::Error>, msg: String },
 }
 
 impl fmt::Display for BcError {
@@ -13,11 +15,19 @@ impl fmt::Display for BcError {
         match self {
             BcError::InvalidArgument { param: Some(p), msg } => write!(f, "Invalid argument '{}': {}", p, msg),
             BcError::InvalidArgument { param: None, msg } => write!(f, "Invalid argument: {}", msg),
+            BcError::IoError { source: Some(s), msg } => write!(f, "I/O error: {} ({})", msg, s),
+            BcError::IoError { source: None, msg } => write!(f, "I/O error: {}", msg),
         }
     }
 }
 
 impl std::error::Error for BcError {}
+
+impl From<std::io::Error> for BcError {
+    fn from(e: std::io::Error) -> Self {
+        BcError::IoError { source: Some(e), msg: "I/O operation failed".to_string() }
+    }
+}
 
 /// Convenience alias for `Result<T, BcError>`.
 pub type BcResult<T> = Result<T, BcError>;
@@ -34,5 +44,20 @@ macro_rules! invalid_arg {
     };
     ($param:expr, $msg:expr) => {
         Err($crate::error::BcError::InvalidArgument { param: Some($param.to_string()), msg: $msg.to_string() })
+    };
+}
+
+/// Creates an `Err(BcError::IoError)`.
+///
+/// Usage:
+/// - `io_error!("msg")`               — no source
+/// - `io_error!(source, "msg")`       — with source
+#[macro_export]
+macro_rules! io_error {
+    ($msg:expr) => {
+        Err($crate::error::BcError::IoError { source: None, msg: $msg.to_string() })
+    };
+    ($source:expr, $msg:expr) => {
+        Err($crate::error::BcError::IoError { source: Some($source), msg: $msg.to_string() })
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod error;
+pub mod util;

--- a/src/util/encoders/hex.rs
+++ b/src/util/encoders/hex.rs
@@ -1,0 +1,219 @@
+//! Hex encoder and decoder.
+
+use std::io::Write;
+use crate::error::{BcError, BcResult};
+
+const ENCODE_TABLE_LOWER: &[u8; 16] = b"0123456789abcdef";
+const ENCODE_TABLE_UPPER: &[u8; 16] = b"0123456789ABCDEF";
+
+/// Decoding table indexed by ASCII value. `0xFF` indicates an invalid character.
+const DECODE_TABLE: [u8; 128] = build_decode_table();
+
+const fn build_decode_table() -> [u8; 128] {
+    let mut table = [0xFFu8; 128];
+    let mut i = 0u8;
+    while i < 10 {
+        table[(b'0' + i) as usize] = i;
+        i += 1;
+    }
+    let mut i = 0u8;
+    while i < 6 {
+        table[(b'a' + i) as usize] = 10 + i;
+        table[(b'A' + i) as usize] = 10 + i;
+        i += 1;
+    }
+    table
+}
+
+fn is_whitespace(c: u8) -> bool {
+    matches!(c, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+fn decode_nibble(c: u8) -> Option<u8> {
+    if c < 128 {
+        let v = DECODE_TABLE[c as usize];
+        if v != 0xFF { return Some(v); }
+    }
+    None
+}
+
+/// Specifies whether hex output should be lowercase or uppercase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HexCase {
+    Lower,
+    Upper,
+}
+
+/// Hex encoder and decoder.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::encoders::hex::{HexEncoder, HexCase};
+///
+/// let lower = HexEncoder::new(HexCase::Lower);
+/// assert_eq!(lower.to_hex_string(&[0xDE, 0xAD]), "dead");
+///
+/// let upper = HexEncoder::new(HexCase::Upper);
+/// assert_eq!(upper.to_hex_string(&[0xDE, 0xAD]), "DEAD");
+/// ```
+pub struct HexEncoder {
+    encode_table: &'static [u8; 16],
+}
+
+impl HexEncoder {
+    /// Creates a hex encoder with the specified case.
+    pub fn new(case: HexCase) -> Self {
+        match case {
+            HexCase::Lower => Self { encode_table: ENCODE_TABLE_LOWER },
+            HexCase::Upper => Self { encode_table: ENCODE_TABLE_UPPER },
+        }
+    }
+
+    /// Encodes `data` as hex, writing to `out`.
+    ///
+    /// Returns the number of bytes written.
+    pub fn encode(&self, data: &[u8], out: &mut impl Write) -> BcResult<usize> {
+        let mut buf = [0u8; 2];
+        for &b in data {
+            buf[0] = self.encode_table[(b >> 4) as usize];
+            buf[1] = self.encode_table[(b & 0xF) as usize];
+            out.write_all(&buf)?;
+        }
+        Ok(data.len() * 2)
+    }
+
+    /// Encodes `data` as a hex string.
+    pub fn to_hex_string(&self, data: &[u8]) -> String {
+        let mut out = Vec::with_capacity(data.len() * 2);
+        self.encode(data, &mut out).expect("Vec<u8> write cannot fail");
+        String::from_utf8(out).expect("hex output is always valid UTF-8")
+    }
+
+    /// Decodes hex bytes into `out`, ignoring whitespace.
+    ///
+    /// Returns the number of bytes written.
+    pub fn decode(&self, data: &[u8], out: &mut impl Write) -> BcResult<usize> {
+        let data: Vec<u8> = data.iter().copied().filter(|&c| !is_whitespace(c)).collect();
+        if !data.len().is_multiple_of(2) {
+            return Err(BcError::InvalidArgument {
+                param: None,
+                msg: "hex data must have an even number of characters".to_string(),
+            });
+        }
+        let mut count = 0;
+        for chunk in data.chunks(2) {
+            let hi = decode_nibble(chunk[0]).ok_or_else(|| BcError::InvalidArgument {
+                param: None,
+                msg: format!("invalid hex character: 0x{:02X}", chunk[0]),
+            })?;
+            let lo = decode_nibble(chunk[1]).ok_or_else(|| BcError::InvalidArgument {
+                param: None,
+                msg: format!("invalid hex character: 0x{:02X}", chunk[1]),
+            })?;
+            out.write_all(&[(hi << 4) | lo])?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    /// Decodes a hex string into `out`, ignoring whitespace.
+    ///
+    /// Returns the number of bytes written.
+    pub fn decode_str(&self, data: &str, out: &mut impl Write) -> BcResult<usize> {
+        self.decode(data.as_bytes(), out)
+    }
+
+    /// Decodes a hex string strictly — no whitespace allowed.
+    ///
+    /// Returns an error if the string contains any non-hex characters.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bc_rust::util::encoders::hex::{HexEncoder, HexCase};
+    /// let encoder = HexEncoder::new(HexCase::Lower);
+    /// assert_eq!(encoder.decode_strict("deadbeef").unwrap(), vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    /// assert!(encoder.decode_strict("dead beef").is_err());
+    /// ```
+    pub fn decode_strict(&self, data: &str) -> BcResult<Vec<u8>> {
+        let bytes = data.as_bytes();
+        if !bytes.len().is_multiple_of(2) {
+            return Err(BcError::InvalidArgument {
+                param: None,
+                msg: "hex data must have an even number of characters".to_string(),
+            });
+        }
+        let mut out = Vec::with_capacity(bytes.len() / 2);
+        for chunk in bytes.chunks(2) {
+            let hi = decode_nibble(chunk[0]).ok_or_else(|| BcError::InvalidArgument {
+                param: None,
+                msg: format!("invalid hex character: 0x{:02X}", chunk[0]),
+            })?;
+            let lo = decode_nibble(chunk[1]).ok_or_else(|| BcError::InvalidArgument {
+                param: None,
+                msg: format!("invalid hex character: 0x{:02X}", chunk[1]),
+            })?;
+            out.push((hi << 4) | lo);
+        }
+        Ok(out)
+    }
+}
+
+impl Default for HexEncoder {
+    fn default() -> Self {
+        Self::new(HexCase::Lower)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_to_hex_string_lower() {
+        let enc = HexEncoder::new(HexCase::Lower);
+        assert_eq!(enc.to_hex_string(&[]), "");
+        assert_eq!(enc.to_hex_string(&[0x00]), "00");
+        assert_eq!(enc.to_hex_string(&[0xDE, 0xAD, 0xBE, 0xEF]), "deadbeef");
+    }
+
+    #[test]
+    fn test_to_hex_string_upper() {
+        let enc = HexEncoder::new(HexCase::Upper);
+        assert_eq!(enc.to_hex_string(&[0xDE, 0xAD, 0xBE, 0xEF]), "DEADBEEF");
+    }
+
+    #[test]
+    fn test_decode_str() {
+        let enc = HexEncoder::new(HexCase::Lower);
+        let mut out = Vec::new();
+        enc.decode_str("deadbeef", &mut out).unwrap();
+        assert_eq!(out, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn test_decode_str_with_whitespace() {
+        let enc = HexEncoder::new(HexCase::Lower);
+        let mut out = Vec::new();
+        enc.decode_str("de ad\nbe\tef", &mut out).unwrap();
+        assert_eq!(out, vec![0xDE, 0xAD, 0xBE, 0xEF]);
+    }
+
+    #[test]
+    fn test_decode_strict() {
+        let enc = HexEncoder::new(HexCase::Lower);
+        assert_eq!(enc.decode_strict("deadbeef").unwrap(), vec![0xDE, 0xAD, 0xBE, 0xEF]);
+        assert!(enc.decode_strict("dead beef").is_err());
+        assert!(enc.decode_strict("xyz").is_err());
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        let enc = HexEncoder::new(HexCase::Lower);
+        let original = vec![0x00, 0x01, 0x7F, 0x80, 0xFF];
+        let encoded = enc.to_hex_string(&original);
+        let decoded = enc.decode_strict(&encoded).unwrap();
+        assert_eq!(original, decoded);
+    }
+}

--- a/src/util/encoders/hex.rs
+++ b/src/util/encoders/hex.rs
@@ -73,6 +73,10 @@ impl HexEncoder {
     /// Encodes `data` as hex, writing to `out`.
     ///
     /// Returns the number of bytes written.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BcError::IoError`] if writing to `out` fails.
     pub fn encode(&self, data: &[u8], out: &mut impl Write) -> BcResult<usize> {
         let mut buf = [0u8; 2];
         for &b in data {
@@ -93,6 +97,12 @@ impl HexEncoder {
     /// Decodes hex bytes into `out`, ignoring whitespace.
     ///
     /// Returns the number of bytes written.
+    ///
+    /// # Errors
+    ///
+    /// - [`BcError::InvalidArgument`] if the data length (after stripping whitespace) is odd.
+    /// - [`BcError::InvalidArgument`] if a non-hex character is encountered.
+    /// - [`BcError::IoError`] if writing to `out` fails.
     pub fn decode(&self, data: &[u8], out: &mut impl Write) -> BcResult<usize> {
         let data: Vec<u8> = data.iter().copied().filter(|&c| !is_whitespace(c)).collect();
         if !data.len().is_multiple_of(2) {
@@ -120,13 +130,20 @@ impl HexEncoder {
     /// Decodes a hex string into `out`, ignoring whitespace.
     ///
     /// Returns the number of bytes written.
+    ///
+    /// # Errors
+    ///
+    /// See [`decode`](Self::decode) for error conditions.
     pub fn decode_str(&self, data: &str, out: &mut impl Write) -> BcResult<usize> {
         self.decode(data.as_bytes(), out)
     }
 
     /// Decodes a hex string strictly — no whitespace allowed.
     ///
-    /// Returns an error if the string contains any non-hex characters.
+    /// # Errors
+    ///
+    /// - [`BcError::InvalidArgument`] if the string length is odd.
+    /// - [`BcError::InvalidArgument`] if any character is not a valid hex digit (whitespace included).
     ///
     /// # Examples
     ///

--- a/src/util/encoders/mod.rs
+++ b/src/util/encoders/mod.rs
@@ -1,0 +1,3 @@
+//! Encoder and decoder utilities.
+
+pub mod hex;

--- a/src/util/integers.rs
+++ b/src/util/integers.rs
@@ -1,0 +1,196 @@
+//! Utility functions for 32-bit integer bit manipulation.
+
+pub const NUM_BITS: u32 = 32;
+pub const NUM_BYTES: u32 = 4;
+
+/// Returns the value of the highest one-bit in `i`.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::integers::highest_one_bit;
+/// assert_eq!(highest_one_bit(0b1010), 0b1000);
+/// ```
+pub fn highest_one_bit(mut i: u32) -> u32 {
+    i |= i >> 1;
+    i |= i >> 2;
+    i |= i >> 4;
+    i |= i >> 8;
+    i |= i >> 16;
+    i - (i >> 1)
+}
+
+/// Returns the value of the lowest one-bit in `i`.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::integers::lowest_one_bit;
+/// assert_eq!(lowest_one_bit(0b1010), 0b0010);
+/// ```
+pub fn lowest_one_bit(i: u32) -> u32 {
+    i & i.wrapping_neg()
+}
+
+/// Returns the number of leading zero bits in `i`.
+///
+/// Equivalent to Rust's built-in [`u32::leading_zeros`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::integers::number_of_leading_zeros;
+/// assert_eq!(number_of_leading_zeros(1), 31);
+/// ```
+pub fn number_of_leading_zeros(i: u32) -> u32 {
+    i.leading_zeros()
+}
+
+/// Returns the number of trailing zero bits in `i`.
+///
+/// Equivalent to Rust's built-in [`u32::trailing_zeros`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::integers::number_of_trailing_zeros;
+/// assert_eq!(number_of_trailing_zeros(0b1000), 3);
+/// ```
+pub fn number_of_trailing_zeros(i: u32) -> u32 {
+    i.trailing_zeros()
+}
+
+/// Returns the number of one-bits in `i` (population count).
+///
+/// Equivalent to Rust's built-in [`u32::count_ones`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::integers::pop_count;
+/// assert_eq!(pop_count(0b1010_1010), 4);
+/// ```
+pub fn pop_count(i: u32) -> u32 {
+    i.count_ones()
+}
+
+/// Returns the value of `i` with its bits reversed.
+///
+/// Equivalent to Rust's built-in [`u32::reverse_bits`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::integers::reverse;
+/// assert_eq!(reverse(0x8000_0000), 0x0000_0001);
+/// ```
+pub fn reverse(i: u32) -> u32 {
+    i.reverse_bits()
+}
+
+/// Returns the value of `i` with its bytes reversed.
+///
+/// Equivalent to Rust's built-in [`u32::swap_bytes`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::integers::reverse_bytes;
+/// assert_eq!(reverse_bytes(0x12345678), 0x78563412);
+/// ```
+pub fn reverse_bytes(i: u32) -> u32 {
+    i.swap_bytes()
+}
+
+/// Returns the value of `i` rotated left by `distance` bits.
+///
+/// Equivalent to Rust's built-in [`u32::rotate_left`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::integers::rotate_left;
+/// assert_eq!(rotate_left(0x8000_0000, 1), 0x0000_0001);
+/// ```
+pub fn rotate_left(i: u32, distance: u32) -> u32 {
+    i.rotate_left(distance)
+}
+
+/// Returns the value of `i` rotated right by `distance` bits.
+///
+/// Equivalent to Rust's built-in [`u32::rotate_right`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::integers::rotate_right;
+/// assert_eq!(rotate_right(0x0000_0001, 1), 0x8000_0000);
+/// ```
+pub fn rotate_right(i: u32, distance: u32) -> u32 {
+    i.rotate_right(distance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_highest_one_bit() {
+        assert_eq!(highest_one_bit(0b0000), 0b0000);
+        assert_eq!(highest_one_bit(0b0001), 0b0001);
+        assert_eq!(highest_one_bit(0b1010), 0b1000);
+        assert_eq!(highest_one_bit(0b1111), 0b1000);
+    }
+
+    #[test]
+    fn test_lowest_one_bit() {
+        assert_eq!(lowest_one_bit(0b0000), 0b0000);
+        assert_eq!(lowest_one_bit(0b1000), 0b1000);
+        assert_eq!(lowest_one_bit(0b1010), 0b0010);
+        assert_eq!(lowest_one_bit(0b1111), 0b0001);
+    }
+
+    #[test]
+    fn test_number_of_leading_zeros() {
+        assert_eq!(number_of_leading_zeros(0), 32);
+        assert_eq!(number_of_leading_zeros(1), 31);
+        assert_eq!(number_of_leading_zeros(0x8000_0000), 0);
+    }
+
+    #[test]
+    fn test_number_of_trailing_zeros() {
+        assert_eq!(number_of_trailing_zeros(0), 32);
+        assert_eq!(number_of_trailing_zeros(1), 0);
+        assert_eq!(number_of_trailing_zeros(0b1000), 3);
+    }
+
+    #[test]
+    fn test_pop_count() {
+        assert_eq!(pop_count(0), 0);
+        assert_eq!(pop_count(0b1010_1010), 4);
+        assert_eq!(pop_count(u32::MAX), 32);
+    }
+
+    #[test]
+    fn test_reverse() {
+        assert_eq!(reverse(0b1000_0000_0000_0000_0000_0000_0000_0000), 0b0000_0001);
+        assert_eq!(reverse(0b0000_0001), 0b1000_0000_0000_0000_0000_0000_0000_0000);
+    }
+
+    #[test]
+    fn test_reverse_bytes() {
+        assert_eq!(reverse_bytes(0x12345678), 0x78563412);
+    }
+
+    #[test]
+    fn test_rotate_left() {
+        assert_eq!(rotate_left(0b0001, 1), 0b0010);
+        assert_eq!(rotate_left(0x8000_0000, 1), 0x0000_0001);
+    }
+
+    #[test]
+    fn test_rotate_right() {
+        assert_eq!(rotate_right(0b0010, 1), 0b0001);
+        assert_eq!(rotate_right(0x0000_0001, 1), 0x8000_0000);
+    }
+}

--- a/src/util/longs.rs
+++ b/src/util/longs.rs
@@ -1,0 +1,197 @@
+//! Utility functions for 64-bit integer bit manipulation.
+
+pub const NUM_BITS: u32 = 64;
+pub const NUM_BYTES: u32 = 8;
+
+/// Returns the value of the highest one-bit in `i`.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::longs::highest_one_bit;
+/// assert_eq!(highest_one_bit(0b1010), 0b1000);
+/// ```
+pub fn highest_one_bit(mut i: u64) -> u64 {
+    i |= i >> 1;
+    i |= i >> 2;
+    i |= i >> 4;
+    i |= i >> 8;
+    i |= i >> 16;
+    i |= i >> 32;
+    i - (i >> 1)
+}
+
+/// Returns the value of the lowest one-bit in `i`.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::longs::lowest_one_bit;
+/// assert_eq!(lowest_one_bit(0b1010), 0b0010);
+/// ```
+pub fn lowest_one_bit(i: u64) -> u64 {
+    i & i.wrapping_neg()
+}
+
+/// Returns the number of leading zero bits in `i`.
+///
+/// Equivalent to Rust's built-in [`u64::leading_zeros`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::longs::number_of_leading_zeros;
+/// assert_eq!(number_of_leading_zeros(1), 63);
+/// ```
+pub fn number_of_leading_zeros(i: u64) -> u32 {
+    i.leading_zeros()
+}
+
+/// Returns the number of trailing zero bits in `i`.
+///
+/// Equivalent to Rust's built-in [`u64::trailing_zeros`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::longs::number_of_trailing_zeros;
+/// assert_eq!(number_of_trailing_zeros(0b1000), 3);
+/// ```
+pub fn number_of_trailing_zeros(i: u64) -> u32 {
+    i.trailing_zeros()
+}
+
+/// Returns the number of one-bits in `i` (population count).
+///
+/// Equivalent to Rust's built-in [`u64::count_ones`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::longs::pop_count;
+/// assert_eq!(pop_count(0b1010_1010), 4);
+/// ```
+pub fn pop_count(i: u64) -> u32 {
+    i.count_ones()
+}
+
+/// Returns the value of `i` with its bits reversed.
+///
+/// Equivalent to Rust's built-in [`u64::reverse_bits`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::longs::reverse;
+/// assert_eq!(reverse(0x8000_0000_0000_0000), 0x0000_0000_0000_0001);
+/// ```
+pub fn reverse(i: u64) -> u64 {
+    i.reverse_bits()
+}
+
+/// Returns the value of `i` with its bytes reversed.
+///
+/// Equivalent to Rust's built-in [`u64::swap_bytes`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::longs::reverse_bytes;
+/// assert_eq!(reverse_bytes(0x0102030405060708), 0x0807060504030201);
+/// ```
+pub fn reverse_bytes(i: u64) -> u64 {
+    i.swap_bytes()
+}
+
+/// Returns the value of `i` rotated left by `distance` bits.
+///
+/// Equivalent to Rust's built-in [`u64::rotate_left`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::longs::rotate_left;
+/// assert_eq!(rotate_left(0x8000_0000_0000_0000, 1), 0x0000_0000_0000_0001);
+/// ```
+pub fn rotate_left(i: u64, distance: u32) -> u64 {
+    i.rotate_left(distance)
+}
+
+/// Returns the value of `i` rotated right by `distance` bits.
+///
+/// Equivalent to Rust's built-in [`u64::rotate_right`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::longs::rotate_right;
+/// assert_eq!(rotate_right(0x0000_0000_0000_0001, 1), 0x8000_0000_0000_0000);
+/// ```
+pub fn rotate_right(i: u64, distance: u32) -> u64 {
+    i.rotate_right(distance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_highest_one_bit() {
+        assert_eq!(highest_one_bit(0b0000), 0b0000);
+        assert_eq!(highest_one_bit(0b0001), 0b0001);
+        assert_eq!(highest_one_bit(0b1010), 0b1000);
+        assert_eq!(highest_one_bit(0b1111), 0b1000);
+    }
+
+    #[test]
+    fn test_lowest_one_bit() {
+        assert_eq!(lowest_one_bit(0b0000), 0b0000);
+        assert_eq!(lowest_one_bit(0b1000), 0b1000);
+        assert_eq!(lowest_one_bit(0b1010), 0b0010);
+        assert_eq!(lowest_one_bit(0b1111), 0b0001);
+    }
+
+    #[test]
+    fn test_number_of_leading_zeros() {
+        assert_eq!(number_of_leading_zeros(0), 64);
+        assert_eq!(number_of_leading_zeros(1), 63);
+        assert_eq!(number_of_leading_zeros(0x8000_0000_0000_0000), 0);
+    }
+
+    #[test]
+    fn test_number_of_trailing_zeros() {
+        assert_eq!(number_of_trailing_zeros(0), 64);
+        assert_eq!(number_of_trailing_zeros(1), 0);
+        assert_eq!(number_of_trailing_zeros(0b1000), 3);
+    }
+
+    #[test]
+    fn test_pop_count() {
+        assert_eq!(pop_count(0), 0);
+        assert_eq!(pop_count(0b1010_1010), 4);
+        assert_eq!(pop_count(u64::MAX), 64);
+    }
+
+    #[test]
+    fn test_reverse() {
+        assert_eq!(reverse(0x8000_0000_0000_0000), 0x0000_0000_0000_0001);
+        assert_eq!(reverse(0x0000_0000_0000_0001), 0x8000_0000_0000_0000);
+    }
+
+    #[test]
+    fn test_reverse_bytes() {
+        assert_eq!(reverse_bytes(0x0102030405060708), 0x0807060504030201);
+    }
+
+    #[test]
+    fn test_rotate_left() {
+        assert_eq!(rotate_left(0b0001, 1), 0b0010);
+        assert_eq!(rotate_left(0x8000_0000_0000_0000, 1), 0x0000_0000_0000_0001);
+    }
+
+    #[test]
+    fn test_rotate_right() {
+        assert_eq!(rotate_right(0b0010, 1), 0b0001);
+        assert_eq!(rotate_right(0x0000_0000_0000_0001, 1), 0x8000_0000_0000_0000);
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,3 @@
+//! Utility modules for the bc-rust library.
+
+pub mod integers;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,5 @@
 //! Utility modules for the bc-rust library.
 
 pub mod integers;
+pub mod longs;
+pub mod shorts;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,6 @@
 //! Utility modules for the bc-rust library.
 
+pub mod encoders;
 pub mod integers;
 pub mod longs;
 pub mod shorts;

--- a/src/util/shorts.rs
+++ b/src/util/shorts.rs
@@ -1,0 +1,195 @@
+//! Utility functions for 16-bit integer bit manipulation.
+
+pub const NUM_BITS: u32 = 16;
+pub const NUM_BYTES: u32 = 2;
+
+/// Returns the value of the highest one-bit in `i`.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::shorts::highest_one_bit;
+/// assert_eq!(highest_one_bit(0b1010), 0b1000);
+/// ```
+pub fn highest_one_bit(mut i: u16) -> u16 {
+    i |= i >> 1;
+    i |= i >> 2;
+    i |= i >> 4;
+    i |= i >> 8;
+    i - (i >> 1)
+}
+
+/// Returns the value of the lowest one-bit in `i`.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::shorts::lowest_one_bit;
+/// assert_eq!(lowest_one_bit(0b1010), 0b0010);
+/// ```
+pub fn lowest_one_bit(i: u16) -> u16 {
+    i & i.wrapping_neg()
+}
+
+/// Returns the number of leading zero bits in `i`.
+///
+/// Equivalent to Rust's built-in [`u16::leading_zeros`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::shorts::number_of_leading_zeros;
+/// assert_eq!(number_of_leading_zeros(1), 15);
+/// ```
+pub fn number_of_leading_zeros(i: u16) -> u32 {
+    i.leading_zeros()
+}
+
+/// Returns the number of trailing zero bits in `i`.
+///
+/// Equivalent to Rust's built-in [`u16::trailing_zeros`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::shorts::number_of_trailing_zeros;
+/// assert_eq!(number_of_trailing_zeros(0b1000), 3);
+/// ```
+pub fn number_of_trailing_zeros(i: u16) -> u32 {
+    i.trailing_zeros()
+}
+
+/// Returns the number of one-bits in `i` (population count).
+///
+/// Equivalent to Rust's built-in [`u16::count_ones`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::shorts::pop_count;
+/// assert_eq!(pop_count(0b1010_1010), 4);
+/// ```
+pub fn pop_count(i: u16) -> u32 {
+    i.count_ones()
+}
+
+/// Returns the value of `i` with its bits reversed.
+///
+/// Equivalent to Rust's built-in [`u16::reverse_bits`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::shorts::reverse;
+/// assert_eq!(reverse(0x8000), 0x0001);
+/// ```
+pub fn reverse(i: u16) -> u16 {
+    i.reverse_bits()
+}
+
+/// Returns the value of `i` with its bytes reversed.
+///
+/// Equivalent to Rust's built-in [`u16::swap_bytes`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::shorts::reverse_bytes;
+/// assert_eq!(reverse_bytes(0x1234), 0x3412);
+/// ```
+pub fn reverse_bytes(i: u16) -> u16 {
+    i.swap_bytes()
+}
+
+/// Returns the value of `i` rotated left by `distance` bits.
+///
+/// Equivalent to Rust's built-in [`u16::rotate_left`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::shorts::rotate_left;
+/// assert_eq!(rotate_left(0x8000, 1), 0x0001);
+/// ```
+pub fn rotate_left(i: u16, distance: u32) -> u16 {
+    i.rotate_left(distance)
+}
+
+/// Returns the value of `i` rotated right by `distance` bits.
+///
+/// Equivalent to Rust's built-in [`u16::rotate_right`]. Prefer using it directly.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::shorts::rotate_right;
+/// assert_eq!(rotate_right(0x0001, 1), 0x8000);
+/// ```
+pub fn rotate_right(i: u16, distance: u32) -> u16 {
+    i.rotate_right(distance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_highest_one_bit() {
+        assert_eq!(highest_one_bit(0b0000), 0b0000);
+        assert_eq!(highest_one_bit(0b0001), 0b0001);
+        assert_eq!(highest_one_bit(0b1010), 0b1000);
+        assert_eq!(highest_one_bit(0b1111), 0b1000);
+    }
+
+    #[test]
+    fn test_lowest_one_bit() {
+        assert_eq!(lowest_one_bit(0b0000), 0b0000);
+        assert_eq!(lowest_one_bit(0b1000), 0b1000);
+        assert_eq!(lowest_one_bit(0b1010), 0b0010);
+        assert_eq!(lowest_one_bit(0b1111), 0b0001);
+    }
+
+    #[test]
+    fn test_number_of_leading_zeros() {
+        assert_eq!(number_of_leading_zeros(0), 16);
+        assert_eq!(number_of_leading_zeros(1), 15);
+        assert_eq!(number_of_leading_zeros(0x8000), 0);
+    }
+
+    #[test]
+    fn test_number_of_trailing_zeros() {
+        assert_eq!(number_of_trailing_zeros(0), 16);
+        assert_eq!(number_of_trailing_zeros(1), 0);
+        assert_eq!(number_of_trailing_zeros(0b1000), 3);
+    }
+
+    #[test]
+    fn test_pop_count() {
+        assert_eq!(pop_count(0), 0);
+        assert_eq!(pop_count(0b1010_1010), 4);
+        assert_eq!(pop_count(u16::MAX), 16);
+    }
+
+    #[test]
+    fn test_reverse() {
+        assert_eq!(reverse(0x8000), 0x0001);
+        assert_eq!(reverse(0x0001), 0x8000);
+    }
+
+    #[test]
+    fn test_reverse_bytes() {
+        assert_eq!(reverse_bytes(0x1234), 0x3412);
+    }
+
+    #[test]
+    fn test_rotate_left() {
+        assert_eq!(rotate_left(0b0001, 1), 0b0010);
+        assert_eq!(rotate_left(0x8000, 1), 0x0001);
+    }
+
+    #[test]
+    fn test_rotate_right() {
+        assert_eq!(rotate_right(0b0010, 1), 0b0001);
+        assert_eq!(rotate_right(0x0001, 1), 0x8000);
+    }
+}


### PR DESCRIPTION
## Summary

- Add `util::integers`, `util::longs`, `util::shorts` — bit manipulation functions for `u32`, `u64`, `u16`
- Add `util::encoders::hex` — `HexEncoder` with `HexCase` enum for lowercase/uppercase output
- Add `BcError::IoError` variant with optional source and message
- Add `io_error!` macro

## Test plan

- [x] All unit tests pass (`cargo test`)
- [x] All doc tests pass
- [x] No Clippy warnings (`cargo clippy`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)