### PR TITLE
feat(util/io/pem): add PEM module

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,8 @@ pub enum BcError {
     SystemTimeError { source: Option<std::time::SystemTimeError>, msg: String },
     /// An operation was called in an invalid state.
     InvalidOperation { msg: String },
+    /// A PEM encoding or decoding error occurred.
+    PemError { msg: String },
 }
 
 impl fmt::Display for BcError {
@@ -30,6 +32,7 @@ impl fmt::Display for BcError {
                 None => write!(f, "System time error: {}", msg),
             },
             BcError::InvalidOperation { msg } => write!(f, "Invalid operation: {}", msg),
+            BcError::PemError { msg } => write!(f, "PEM error: {}", msg),
         }
     }
 }
@@ -89,6 +92,17 @@ macro_rules! system_time_error {
 macro_rules! invalid_op {
     ($msg:expr) => {
         Err($crate::error::BcError::InvalidOperation { msg: $msg.to_string() })
+    };
+}
+
+/// Creates an `Err(BcError::PemError)`.
+///
+/// Usage:
+/// - `pem_error!("msg")`
+#[macro_export]
+macro_rules! pem_error {
+    ($msg:expr) => {
+        Err($crate::error::BcError::PemError { msg: $msg.to_string() })
     };
 }
 

--- a/src/util/io/mod.rs
+++ b/src/util/io/mod.rs
@@ -21,6 +21,7 @@
 //! | `TeeOutputStream.cs` | [`tee_writer`] | [`std::io::Write`] wrapper that copies to a secondary [`std::io::Write`] |
 
 pub mod limited_reader;
+pub mod pem;
 pub mod pushback_reader;
 pub mod streams;
 pub mod tee_reader;

--- a/src/util/io/pem/mod.rs
+++ b/src/util/io/pem/mod.rs
@@ -1,0 +1,25 @@
+//! PEM encoding and decoding utilities.
+//!
+//! Port of `util/io/pem/` from bc-csharp.
+//!
+//! PEM (Privacy-Enhanced Mail) is a Base64-encoded format with header/footer
+//! markers such as `-----BEGIN CERTIFICATE-----` and `-----END CERTIFICATE-----`.
+//!
+//! ## bc-csharp mapping
+//!
+//! | bc-csharp | bc-rust | Notes |
+//! |-----------|---------|-------|
+//! | `PemGenerationException.cs` | — | Not ported — use [`crate::error::BcError`] instead |
+//! | `PemHeader.cs` | [`pem_header::PemHeader`] | PEM header name-value pair |
+//! | `PemObject.cs` | [`pem_object::PemObject`] | PEM object with type, headers and content |
+//! | `PemObjectGenerator.cs` | [`pem_object_generator::PemObjectGenerator`] | Trait for generating PEM objects |
+//! | `PemObjectParser.cs` | [`pem_object_parser::PemObjectParser`] | Trait for parsing PEM objects |
+//! | `PemReader.cs` | [`pem_reader::PemReader`] | Reads PEM-formatted data |
+//! | `PemWriter.cs` | [`pem_writer::PemWriter`] | Writes PEM-formatted data |
+
+pub mod pem_header;
+pub mod pem_object;
+pub mod pem_object_generator;
+pub mod pem_object_parser;
+pub mod pem_reader;
+pub mod pem_writer;

--- a/src/util/io/pem/pem_header.rs
+++ b/src/util/io/pem/pem_header.rs
@@ -1,0 +1,83 @@
+//! PEM header name-value pair.
+//!
+//! Port of `PemHeader.cs` from bc-csharp.
+
+use std::fmt;
+
+/// A PEM header name-value pair.
+///
+/// PEM files may contain optional headers between the `-----BEGIN ...-----`
+/// marker and the Base64-encoded content.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::io::pem::pem_header::PemHeader;
+///
+/// let header = PemHeader::new("Proc-Type", "4,ENCRYPTED");
+/// assert_eq!(header.name(), "Proc-Type");
+/// assert_eq!(header.value(), "4,ENCRYPTED");
+/// assert_eq!(header.to_string(), "Proc-Type: 4,ENCRYPTED");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct PemHeader {
+    name: String,
+    value: String,
+}
+
+impl PemHeader {
+    /// Creates a new `PemHeader` with the given name and value.
+    pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
+        Self { name: name.into(), value: value.into() }
+    }
+
+    /// Returns the header name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the header value.
+    pub fn value(&self) -> &str {
+        &self.value
+    }
+}
+
+impl fmt::Display for PemHeader {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}: {}", self.name, self.value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let h = PemHeader::new("Proc-Type", "4,ENCRYPTED");
+        assert_eq!(h.name(), "Proc-Type");
+        assert_eq!(h.value(), "4,ENCRYPTED");
+    }
+
+    #[test]
+    fn test_display() {
+        let h = PemHeader::new("Proc-Type", "4,ENCRYPTED");
+        assert_eq!(h.to_string(), "Proc-Type: 4,ENCRYPTED");
+    }
+
+    #[test]
+    fn test_equality() {
+        let h1 = PemHeader::new("Proc-Type", "4,ENCRYPTED");
+        let h2 = PemHeader::new("Proc-Type", "4,ENCRYPTED");
+        let h3 = PemHeader::new("DEK-Info", "AES-128-CBC");
+        assert_eq!(h1, h2);
+        assert_ne!(h1, h3);
+    }
+
+    #[test]
+    fn test_clone() {
+        let h1 = PemHeader::new("Proc-Type", "4,ENCRYPTED");
+        let h2 = h1.clone();
+        assert_eq!(h1, h2);
+    }
+}

--- a/src/util/io/pem/pem_object.rs
+++ b/src/util/io/pem/pem_object.rs
@@ -1,0 +1,101 @@
+//! PEM object containing type, headers and Base64-encoded content.
+//!
+//! Port of `PemObject.cs` from bc-csharp.
+
+use crate::error::BcResult;
+use super::pem_header::PemHeader;
+use super::pem_object_generator::PemObjectGenerator;
+
+/// A PEM object with a type, optional headers, and binary content.
+///
+/// Represents a single PEM block, e.g.:
+///
+/// ```text
+/// -----BEGIN CERTIFICATE-----
+/// Proc-Type: 4,ENCRYPTED
+///
+/// Base64EncodedContent...
+/// -----END CERTIFICATE-----
+/// ```
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::io::pem::pem_object::PemObject;
+///
+/// let obj = PemObject::new("CERTIFICATE", vec![0x01, 0x02, 0x03]);
+/// assert_eq!(obj.pem_type(), "CERTIFICATE");
+/// assert!(obj.headers().is_empty());
+/// assert_eq!(obj.content(), &[0x01, 0x02, 0x03]);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PemObject {
+    pem_type: String,
+    headers: Vec<PemHeader>,
+    content: Vec<u8>,
+}
+
+impl PemObject {
+    /// Creates a new `PemObject` with the given type and content, and no headers.
+    pub fn new(pem_type: impl Into<String>, content: Vec<u8>) -> Self {
+        Self { pem_type: pem_type.into(), headers: Vec::new(), content }
+    }
+
+    /// Creates a new `PemObject` with the given type, headers, and content.
+    pub fn with_headers(
+        pem_type: impl Into<String>,
+        headers: Vec<PemHeader>,
+        content: Vec<u8>,
+    ) -> Self {
+        Self { pem_type: pem_type.into(), headers, content }
+    }
+
+    /// Returns the PEM type (e.g. `"CERTIFICATE"`, `"RSA PRIVATE KEY"`).
+    pub fn pem_type(&self) -> &str {
+        &self.pem_type
+    }
+
+    /// Returns the PEM headers.
+    pub fn headers(&self) -> &[PemHeader] {
+        &self.headers
+    }
+
+    /// Returns the binary content.
+    pub fn content(&self) -> &[u8] {
+        &self.content
+    }
+}
+
+impl PemObjectGenerator for PemObject {
+    fn generate(&self) -> BcResult<PemObject> {
+        Ok(self.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new() {
+        let obj = PemObject::new("CERTIFICATE", vec![0x01, 0x02, 0x03]);
+        assert_eq!(obj.pem_type(), "CERTIFICATE");
+        assert!(obj.headers().is_empty());
+        assert_eq!(obj.content(), &[0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn test_with_headers() {
+        let headers = vec![PemHeader::new("Proc-Type", "4,ENCRYPTED")];
+        let obj = PemObject::with_headers("RSA PRIVATE KEY", headers.clone(), vec![0xAB]);
+        assert_eq!(obj.pem_type(), "RSA PRIVATE KEY");
+        assert_eq!(obj.headers(), headers.as_slice());
+        assert_eq!(obj.content(), &[0xAB]);
+    }
+
+    #[test]
+    fn test_clone() {
+        let obj = PemObject::new("CERTIFICATE", vec![0x01]);
+        assert_eq!(obj.clone(), obj);
+    }
+}

--- a/src/util/io/pem/pem_object_generator.rs
+++ b/src/util/io/pem/pem_object_generator.rs
@@ -1,0 +1,18 @@
+//! Trait for generating PEM objects.
+//!
+//! Port of `PemObjectGenerator.cs` from bc-csharp.
+
+use crate::error::BcResult;
+use super::pem_object::PemObject;
+
+/// Trait for types that can generate a [`PemObject`].
+///
+/// Equivalent to bc-csharp's `PemObjectGenerator` interface.
+pub trait PemObjectGenerator {
+    /// Generates a [`PemObject`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::BcError::PemError`] if generation fails.
+    fn generate(&self) -> BcResult<PemObject>;
+}

--- a/src/util/io/pem/pem_object_parser.rs
+++ b/src/util/io/pem/pem_object_parser.rs
@@ -1,0 +1,29 @@
+//! Trait for parsing PEM objects into concrete types.
+//!
+//! Port of `PemObjectParser.cs` from bc-csharp.
+
+use crate::error::BcResult;
+use super::pem_object::PemObject;
+
+/// Trait for types that can parse a [`PemObject`] into a concrete type.
+///
+/// Equivalent to bc-csharp's `PemObjectParser` interface.
+///
+/// Unlike bc-csharp which returns `object`, Rust uses an associated type
+/// to specify the concrete output type at compile time.
+///
+/// # Note
+///
+/// Implementations will be added when concrete cryptographic types
+/// (certificates, keys, etc.) are available.
+pub trait PemObjectParser {
+    /// The concrete type produced by parsing.
+    type Output;
+
+    /// Parses a [`PemObject`] into [`Self::Output`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::error::BcError::PemError`] if parsing fails.
+    fn parse_object(&self, obj: &PemObject) -> BcResult<Self::Output>;
+}

--- a/src/util/io/pem/pem_reader.rs
+++ b/src/util/io/pem/pem_reader.rs
@@ -1,0 +1,203 @@
+//! PEM reader.
+//!
+//! Port of `PemReader.cs` from bc-csharp.
+//!
+//! Unlike bc-csharp which uses character-by-character parsing with a pushback
+//! stack, this implementation uses [`std::io::BufRead`] for line-oriented
+//! reading, which is simpler and idiomatic in Rust.
+
+use std::io::BufRead;
+use crate::error::{BcError, BcResult};
+use crate::util::encoders::base64::{Base64Alphabet, Base64Encoder};
+use super::pem_header::PemHeader;
+use super::pem_object::PemObject;
+
+/// Reads PEM-formatted data from a [`BufRead`] input.
+///
+/// Equivalent to bc-csharp's `PemReader`.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::io::pem::pem_reader::PemReader;
+///
+/// let pem = b"-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n";
+/// let mut reader = PemReader::new(pem.as_ref());
+/// let obj = reader.read_pem_object().unwrap().unwrap();
+/// assert_eq!(obj.pem_type(), "CERTIFICATE");
+/// assert_eq!(obj.content(), &[0x01, 0x02, 0x03]);
+/// ```
+pub struct PemReader<R: BufRead> {
+    reader: R,
+}
+
+impl<R: BufRead> PemReader<R> {
+    /// Creates a new `PemReader` wrapping `reader`.
+    pub fn new(reader: R) -> Self {
+        Self { reader }
+    }
+
+    /// Reads the next PEM object from the input.
+    ///
+    /// Returns `Ok(None)` at end of input.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BcError::PemError`] if the PEM data is malformed.
+    /// Returns [`BcError::IoError`] if reading fails.
+    pub fn read_pem_object(&mut self) -> BcResult<Option<PemObject>> {
+        let pem_type = match self.find_begin()? {
+            Some(t) => t,
+            None => return Ok(None),
+        };
+
+        let mut headers = Vec::new();
+        let mut base64_data = String::new();
+        let mut in_headers = true;
+        let mut line = String::new();
+
+        loop {
+            line.clear();
+            if self.reader.read_line(&mut line)? == 0 {
+                return Err(BcError::PemError {
+                    msg: "unexpected end of input before END marker".to_string(),
+                });
+            }
+
+            let trimmed = line.trim();
+
+            // END marker
+            if trimmed.starts_with("-----END ") && trimmed.ends_with("-----") {
+                let end_type = &trimmed[9..trimmed.len() - 5];
+                if end_type != pem_type {
+                    return Err(BcError::PemError {
+                        msg: format!("expected END {}, got END {}", pem_type, end_type),
+                    });
+                }
+                break;
+            }
+
+            // Empty line separates headers from content
+            if trimmed.is_empty() {
+                in_headers = false;
+                continue;
+            }
+
+            // Header line (key: value)
+            if in_headers {
+                if let Some(pos) = trimmed.find(':') {
+                    let key = trimmed[..pos].trim();
+                    let val = trimmed[pos + 1..].trim();
+                    headers.push(PemHeader::new(key, val));
+                    continue;
+                }
+                in_headers = false; // no colon — it's content
+            }
+
+            base64_data.push_str(trimmed);
+        }
+
+        let encoder = Base64Encoder::new(Base64Alphabet::Standard);
+        let content = encoder.decode_str(&base64_data)?;
+
+        Ok(Some(PemObject::with_headers(pem_type, headers, content)))
+    }
+
+    /// Scans forward for a `-----BEGIN TYPE-----` marker.
+    ///
+    /// Returns `Ok(None)` if EOF is reached without finding one.
+    fn find_begin(&mut self) -> BcResult<Option<String>> {
+        let mut line = String::new();
+        loop {
+            line.clear();
+            if self.reader.read_line(&mut line)? == 0 {
+                return Ok(None);
+            }
+            let trimmed = line.trim();
+            if trimmed.starts_with("-----BEGIN ") && trimmed.ends_with("-----") {
+                let pem_type = trimmed[11..trimmed.len() - 5].trim().to_string();
+                if pem_type.is_empty() {
+                    return Err(BcError::PemError {
+                        msg: "empty PEM type in BEGIN marker".to_string(),
+                    });
+                }
+                return Ok(Some(pem_type));
+            } else if trimmed.starts_with("-----BEGIN") {
+                return Err(BcError::PemError {
+                    msg: "malformed PEM BEGIN marker".to_string(),
+                });
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    #[test]
+    fn test_read_simple() {
+        let pem = b"-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n";
+        let mut reader = PemReader::new(pem.as_ref());
+        let obj = reader.read_pem_object().unwrap().unwrap();
+        assert_eq!(obj.pem_type(), "CERTIFICATE");
+        assert_eq!(obj.content(), &[0x01, 0x02, 0x03]);
+        assert!(obj.headers().is_empty());
+    }
+
+    #[test]
+    fn test_read_with_headers() {
+        let pem = "-----BEGIN RSA PRIVATE KEY-----\nProc-Type: 4,ENCRYPTED\nDEK-Info: AES-128-CBC,ABC\n\nAQID\n-----END RSA PRIVATE KEY-----\n";
+        let mut reader = PemReader::new(pem.as_bytes());
+        let obj = reader.read_pem_object().unwrap().unwrap();
+        assert_eq!(obj.pem_type(), "RSA PRIVATE KEY");
+        assert_eq!(obj.headers().len(), 2);
+        assert_eq!(obj.headers()[0].name(), "Proc-Type");
+        assert_eq!(obj.headers()[0].value(), "4,ENCRYPTED");
+    }
+
+    #[test]
+    fn test_read_eof() {
+        let pem = b"no pem here";
+        let mut reader = PemReader::new(pem.as_ref());
+        assert!(reader.read_pem_object().unwrap().is_none());
+    }
+
+    #[test]
+    fn test_read_ignores_leading_text() {
+        let pem = "some text\n-----BEGIN CERTIFICATE-----\nAQID\n-----END CERTIFICATE-----\n";
+        let mut reader = PemReader::new(pem.as_bytes());
+        let obj = reader.read_pem_object().unwrap().unwrap();
+        assert_eq!(obj.pem_type(), "CERTIFICATE");
+    }
+
+    #[test]
+    fn test_roundtrip() {
+        use crate::util::io::pem::pem_writer::PemWriter;
+
+        let original = PemObject::new("CERTIFICATE", vec![0x01, 0x02, 0x03, 0x04, 0x05]);
+        let mut buf = Vec::new();
+        PemWriter::new(&mut buf).write_object(&original).unwrap();
+
+        let mut reader = PemReader::new(Cursor::new(buf));
+        let parsed = reader.read_pem_object().unwrap().unwrap();
+        assert_eq!(parsed.pem_type(), original.pem_type());
+        assert_eq!(parsed.content(), original.content());
+    }
+
+    #[test]
+    fn test_malformed_begin() {
+        // "-----BEGIN \n" — BEGIN with no type, port of bc-csharp TestMalformed
+        let pem = "-----BEGIN \n";
+        let mut reader = PemReader::new(pem.as_bytes());
+        assert!(reader.read_pem_object().is_err());
+    }
+
+    #[test]
+    fn test_wrong_end_type() {
+        let pem = "-----BEGIN CERTIFICATE-----\nAQID\n-----END OTHER-----\n";
+        let mut reader = PemReader::new(pem.as_bytes());
+        assert!(reader.read_pem_object().is_err());
+    }
+}

--- a/src/util/io/pem/pem_writer.rs
+++ b/src/util/io/pem/pem_writer.rs
@@ -1,0 +1,183 @@
+//! PEM writer.
+//!
+//! Port of `PemWriter.cs` from bc-csharp.
+
+use std::io::Write;
+use crate::error::BcResult;
+use crate::util::encoders::base64::{Base64Alphabet, Base64Encoder};
+use super::pem_object_generator::PemObjectGenerator;
+
+/// Line length for Base64-encoded PEM content, as per RFC 1421.
+const LINE_LENGTH: usize = 64;
+
+/// Writes PEM-formatted data to a [`Write`] output.
+///
+/// Equivalent to bc-csharp's `PemWriter`.
+///
+/// # Examples
+///
+/// ```
+/// use bc_rust::util::io::pem::pem_object::PemObject;
+/// use bc_rust::util::io::pem::pem_writer::PemWriter;
+///
+/// let obj = PemObject::new("CERTIFICATE", vec![0x01, 0x02, 0x03]);
+/// let mut out = Vec::new();
+/// let mut writer = PemWriter::new(&mut out);
+/// writer.write_object(&obj).unwrap();
+///
+/// let pem = String::from_utf8(out).unwrap();
+/// assert!(pem.starts_with("-----BEGIN CERTIFICATE-----\n"));
+/// assert!(pem.ends_with("-----END CERTIFICATE-----\n"));
+/// ```
+pub struct PemWriter<W: Write> {
+    writer: W,
+}
+
+impl<W: Write> PemWriter<W> {
+    /// Creates a new `PemWriter` wrapping `writer`.
+    pub fn new(writer: W) -> Self {
+        Self { writer }
+    }
+
+    /// Returns the number of bytes required to encode `obj` as PEM.
+    ///
+    /// Equivalent to bc-csharp's `PemWriter.GetOutputSize`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bc_rust::util::io::pem::pem_object::PemObject;
+    /// use bc_rust::util::io::pem::pem_writer::PemWriter;
+    ///
+    /// let obj = PemObject::new("CERTIFICATE", vec![0x01, 0x02, 0x03]);
+    /// let mut out = Vec::new();
+    /// let mut writer = PemWriter::new(&mut out);
+    /// let size = writer.get_output_size(&obj);
+    /// writer.write_object(&obj).unwrap();
+    /// assert_eq!(out.len(), size);
+    /// ```
+    pub fn get_output_size(&self, obj: &super::pem_object::PemObject) -> usize {
+        // BEGIN + END lines: "-----BEGIN TYPE-----\n" + "-----END TYPE-----\n"
+        let mut size = 2 * (obj.pem_type().len() + 10 + 1) + 10;
+
+        // Headers + empty separator line
+        if !obj.headers().is_empty() {
+            for h in obj.headers() {
+                size += h.name().len() + 2 + h.value().len() + 1;
+            }
+            size += 1; // empty line
+        }
+
+        // Base64 content + newlines
+        let data_len = obj.content().len().div_ceil(3) * 4;
+        size += data_len + data_len.div_ceil(LINE_LENGTH);
+
+        size
+    }
+
+    /// Writes a PEM object to the output.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`crate::error::BcError::PemError`] if generation fails.
+    /// - Returns [`crate::error::BcError::IoError`] if writing fails.
+    pub fn write_object(&mut self, obj: &impl PemObjectGenerator) -> BcResult<()> {
+        let obj = obj.generate()?;
+
+        writeln!(self.writer, "-----BEGIN {}-----", obj.pem_type())?;
+
+        if !obj.headers().is_empty() {
+            for header in obj.headers() {
+                writeln!(self.writer, "{}: {}", header.name(), header.value())?;
+            }
+            writeln!(self.writer)?;
+        }
+
+        let encoder = Base64Encoder::new(Base64Alphabet::Standard);
+        let encoded = encoder.to_base64_string(obj.content());
+        for chunk in encoded.as_bytes().chunks(LINE_LENGTH) {
+            self.writer.write_all(chunk)?;
+            writeln!(self.writer)?;
+        }
+
+        writeln!(self.writer, "-----END {}-----", obj.pem_type())?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::util::io::pem::pem_header::PemHeader;
+    use crate::util::io::pem::pem_object::PemObject;
+
+    fn write_to_string(obj: &PemObject) -> String {
+        let mut out = Vec::new();
+        PemWriter::new(&mut out).write_object(obj).unwrap();
+        String::from_utf8(out).unwrap()
+    }
+
+    #[test]
+    fn test_write_simple() {
+        let obj = PemObject::new("CERTIFICATE", vec![0x01, 0x02, 0x03]);
+        let pem = write_to_string(&obj);
+        assert!(pem.starts_with("-----BEGIN CERTIFICATE-----\n"));
+        assert!(pem.ends_with("-----END CERTIFICATE-----\n"));
+    }
+
+    #[test]
+    fn test_write_with_headers() {
+        let headers = vec![PemHeader::new("Proc-Type", "4,ENCRYPTED")];
+        let obj = PemObject::with_headers("RSA PRIVATE KEY", headers, vec![0xAB, 0xCD]);
+        let pem = write_to_string(&obj);
+        assert!(pem.contains("Proc-Type: 4,ENCRYPTED\n"));
+        assert!(pem.contains("-----BEGIN RSA PRIVATE KEY-----\n"));
+        assert!(pem.contains("-----END RSA PRIVATE KEY-----\n"));
+    }
+
+    #[test]
+    fn test_write_long_content_wraps_at_64() {
+        let content = vec![0xABu8; 60]; // produces 80 Base64 chars
+        let obj = PemObject::new("DATA", content);
+        let pem = write_to_string(&obj);
+        for line in pem.lines() {
+            if line.starts_with("-----") { continue; }
+            assert!(line.len() <= LINE_LENGTH, "line too long: {}", line.len());
+        }
+    }
+
+    fn length_test(pem_type: &str, headers: Vec<PemHeader>, content: Vec<u8>) {
+        let obj = PemObject::with_headers(pem_type, headers, content);
+        let mut out = Vec::new();
+        let mut writer = PemWriter::new(&mut out);
+        let size = writer.get_output_size(&obj);
+        writer.write_object(&obj).unwrap();
+        assert_eq!(out.len(), size, "size mismatch for content len {}", obj.content().len());
+    }
+
+    #[test]
+    fn test_pem_length_various_sizes() {
+        for i in 1..60 {
+            length_test("CERTIFICATE", vec![], vec![0u8; i]);
+        }
+        for i in [100, 101, 102, 103, 1000, 1001, 1002, 1003] {
+            length_test("CERTIFICATE", vec![], vec![0u8; i]);
+        }
+    }
+
+    #[test]
+    fn test_pem_length_with_headers() {
+        let headers = vec![
+            PemHeader::new("Proc-Type", "4,ENCRYPTED"),
+            PemHeader::new("DEK-Info", "DES3,0001020304050607"),
+        ];
+        length_test("RSA PRIVATE KEY", headers, vec![0u8; 103]);
+    }
+
+    #[test]
+    fn test_write_empty_content() {
+        let obj = PemObject::new("CERTIFICATE", vec![]);
+        let pem = write_to_string(&obj);
+        assert_eq!(pem, "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----\n");
+    }
+}


### PR DESCRIPTION
## Summary

- Add `BcError::PemError` variant with `pem_error!` macro
- Add `PemHeader` — name-value pair (port of `PemHeader.cs`)
- Add `PemObject` — PEM block with type, headers and content (port of `PemObject.cs`)
- Add `PemObjectGenerator` trait (port of `PemObjectGenerator.cs`)
- Add `PemObjectParser` trait with associated type (port of `PemObjectParser.cs`)
- Add `PemWriter` with `get_output_size` (port of `PemWriter.cs`)
- Add `PemReader` — uses line-oriented `BufRead` instead of bc-csharp's character-by-character pushback approach
- Tests ported from `AllTests.cs`: length tests and malformed input detection

## Test plan

- [ ] `cargo test` — all 155 tests pass
- [ ] `cargo clippy` — no warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)