### PR TITLE
Add complete BZip2 compression/decompression support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # bc-rust
 
-## 專案目標
+## Project Goal
 
-將 [bc-csharp](https://github.com/bcgit/bc-csharp)（Bouncy Castle C#）密碼學函式庫移植到 Rust，作為學習 Rust 的練習。也學習各種演算法。目標發佈到 crates.io 供 Rust 開發者使用。
+Port [bc-csharp](https://github.com/bcgit/bc-csharp) (Bouncy Castle C#) cryptography library to Rust as a learning exercise for both Rust and cryptographic algorithms. The goal is to publish it on crates.io for Rust developers.
+
+## Code Quality
+
+After completing any code changes, run Clippy and fix all warnings:
+
+```
+cargo clippy -- -D warnings
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# bc-rust
+
+## 專案目標
+
+將 [bc-csharp](https://github.com/bcgit/bc-csharp)（Bouncy Castle C#）密碼學函式庫移植到 Rust，作為學習 Rust 的練習。也學習各種演算法。目標發佈到 crates.io 供 Rust 開發者使用。

--- a/src/util/bzip2/bzip2_reader.rs
+++ b/src/util/bzip2/bzip2_reader.rs
@@ -1,0 +1,800 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package is based on the work done by Keiron Liddle, Aftex Software
+// <keiron@aftexsw.com> to whom the Ant project is very grateful for his
+// great code.
+
+//! BZip2 decompression reader.
+//!
+//! Port of `CBZip2InputStream.cs` from bc-csharp.
+
+use std::io::{self, Read};
+
+use super::constants::*;
+use super::crc::Crc;
+
+/// Output state machine for the reverse-RLE pass.
+///
+/// Because [`BZip2Reader`] is a pull model (bytes are emitted only when
+/// [`Read::read`] is called), the inner decode loop must be interruptible.
+/// This enum records where in the loop execution was suspended.
+///
+/// ```text
+/// StartBlock   — waiting to read the next block header from the stream
+/// RandPartA    — reading the first byte of a new BWT position
+/// RandPartB    — accumulating a run (j2 counts identical bytes so far)
+/// RandPartC    — in a run of ≥ 4: emitting the repeated byte z more times
+/// NoProcess    — end-of-stream reached; no more data to produce
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReaderState {
+    StartBlock,
+    RandPartA,
+    RandPartB,
+    RandPartC,
+    NoProcess,
+}
+
+/// BZip2 decompression reader.
+///
+/// Wraps an inner [`Read`] containing a bzip2-compressed stream and
+/// decompresses it transparently. Implements [`Read`] so it can be used
+/// anywhere a readable source is expected.
+///
+/// # Decompression pipeline
+///
+/// ```text
+/// bzip2 stream
+///   → bit reader
+///   → Huffman decode (per G_SIZE-symbol group, using the elected table)
+///   → inverse MTF (move-to-front)
+///   → inverse BWT (using tt[] walking-pointer technique)
+///   → inverse RLE (run of ≥ 4 identical bytes followed by repeat count)
+///   → original bytes
+/// ```
+pub struct BZip2Reader<R: Read> {
+    inner: R,
+
+    // --- Stream-level state ---
+    /// Compression level read from the stream header (1–9).
+    block_size_100k: usize,
+    /// Set when the EOS marker has been seen and CRC verified.
+    stream_end: bool,
+
+    // --- Bit input buffer ---
+    /// Bits waiting to be consumed, stored MSB-first in the low `bs_live` bits.
+    bs_buff: i32,
+    /// Number of valid bits currently in `bs_buff` (counts up from 0 to 32).
+    bs_live: i32,
+
+    // --- CRC ---
+    /// Per-block CRC calculator (reset at the start of each block).
+    block_crc: Crc,
+    /// Block CRC as stored in the stream header (verified at end of block).
+    stored_block_crc: u32,
+    /// Combined stream CRC as stored in the EOS marker.
+    stored_stream_crc: u32,
+    /// Combined stream CRC accumulated from each block's final CRC.
+    computed_stream_crc: u32,
+
+    // --- Block header fields ---
+    /// BWT origin pointer: which rotation is the original string.
+    orig_ptr: usize,
+    /// Whether this block was randomised before compression.
+    block_randomised: bool,
+
+    // --- BWT inverse reconstruction ---
+    /// Combined BWT inverse array: `tt[i] = (next_index << 8) | byte_value`.
+    /// Built from `ll8[]` and `unzftab[]` during `setup_block`.
+    tt: Vec<u32>,
+    /// Walking pointer into `tt[]` — advanced one step per output byte.
+    t_pos: usize,
+    /// Number of original bytes remaining to emit from the current block.
+    count: usize,
+    /// Per-byte-value frequency table, used to reconstruct `tt[]`.
+    unzftab: [usize; 256],
+
+    // --- Symbol alphabet ---
+    /// Which byte values are present in this block.
+    in_use: [bool; 256],
+    /// Number of distinct byte values in use.
+    n_in_use: usize,
+    /// Maps MTF rank (0-based) to actual byte value.
+    seq_to_unseq: [u8; 256],
+
+    // --- Huffman selector tables ---
+    /// Number of Huffman tables used in this block.
+    n_groups: usize,
+    /// Number of selector entries.
+    n_selectors: usize,
+    /// `selector[i]` — which Huffman table covers the i-th G_SIZE group
+    /// (after MTF-decoding the stored `selector_mtf` values).
+    selector: Vec<u8>,
+    /// Raw selector values as stored in the stream (MTF-encoded).
+    selector_mtf: Vec<u8>,
+
+    // --- Huffman decode tables (one set per group) ---
+    /// `limit[g][l]`  — largest Huffman code of length l in group g.
+    limit: [[i32; MAX_CODE_LEN + 1]; N_GROUPS],
+    /// `base[g][l]`   — first symbol index for codes of length l in group g.
+    base:  [[i32; MAX_CODE_LEN + 1]; N_GROUPS],
+    /// `perm[g][i]`   — symbol at canonical position i in group g.
+    perm:  [[i32; MAX_ALPHA_SIZE]; N_GROUPS],
+    /// Minimum code length for each group.
+    min_lens: [i32; N_GROUPS],
+
+    // --- Output state machine ---
+    current_state: ReaderState,
+
+    // RLE decode variables — see `SetupRandPartA` / `SetupRandPartB/C` in C#
+    /// Previous character seen (used to detect runs of ≥ 4).
+    ch_prev: u8,
+    /// Run-accumulation counter (1 = first occurrence, 4 = trigger repeat read).
+    j2: i32,
+    /// Repeat count read from the 5th byte of a run (how many more to emit).
+    z: i32,
+    /// Most recently decoded BWT character.
+    t_ch: u8,
+    /// Number of bytes consumed from the BWT block so far.
+    t_i: usize,
+
+    // --- Randomisation state (for randomised blocks) ---
+    /// Remaining steps until the next bit-flip from RNUMS.
+    r_n_to_go: i32,
+    /// Current position in the RNUMS table.
+    r_t_pos: usize,
+
+    // --- Output byte being assembled for the caller ---
+    /// The current output character, or -1 if none is pending.
+    current_char: i32,
+    /// How many times `current_char` remains to be written to the caller's buffer.
+    output_count: usize,
+}
+
+impl<R: Read> BZip2Reader<R> {
+    /// Open a bzip2-compressed stream for reading.
+    ///
+    /// Reads and validates the 4-byte stream header (`BZh{n}`) immediately.
+    /// Returns an error if the header is missing or malformed.
+    pub fn new(mut inner: R) -> io::Result<Self> {
+        // Read "BZh{n}"
+        let mut hdr = [0u8; 4];
+        inner.read_exact(&mut hdr)?;
+
+        if hdr[0] != b'B' || hdr[1] != b'Z' || hdr[2] != b'h' {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "not a bzip2 stream",
+            ));
+        }
+        let block_size_100k = match hdr[3] {
+            b'1'..=b'9' => (hdr[3] - b'0') as usize,
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid bzip2 block size digit",
+                ))
+            }
+        };
+
+        let n = BASE_BLOCK_SIZE * block_size_100k;
+
+        Ok(Self {
+            inner,
+            block_size_100k,
+            stream_end: false,
+            bs_buff: 0,
+            bs_live: 0,
+            block_crc: Crc::new(),
+            stored_block_crc: 0,
+            stored_stream_crc: 0,
+            computed_stream_crc: 0,
+            orig_ptr: 0,
+            block_randomised: false,
+            tt: vec![0u32; n],
+            t_pos: 0,
+            count: 0,
+            unzftab: [0usize; 256],
+            in_use: [false; 256],
+            n_in_use: 0,
+            seq_to_unseq: [0u8; 256],
+            n_groups: 0,
+            n_selectors: 0,
+            selector: vec![0u8; MAX_SELECTORS],
+            selector_mtf: vec![0u8; MAX_SELECTORS],
+            limit: [[0i32; MAX_CODE_LEN + 1]; N_GROUPS],
+            base:  [[0i32; MAX_CODE_LEN + 1]; N_GROUPS],
+            perm:  [[0i32; MAX_ALPHA_SIZE]; N_GROUPS],
+            min_lens: [0i32; N_GROUPS],
+            current_state: ReaderState::StartBlock,
+            ch_prev: 0,
+            j2: 0,
+            z: 0,
+            t_ch: 0,
+            t_i: 0,
+            r_n_to_go: 0,
+            r_t_pos: 0,
+            current_char: -1,
+            output_count: 0,
+        })
+    }
+}
+
+impl<R: Read> BZip2Reader<R> {
+    // -----------------------------------------------------------------------
+    // Bit-level input
+    // -----------------------------------------------------------------------
+
+    /// Refill `bs_buff` with one byte from the inner reader.
+    ///
+    /// Shifts the existing bits left by 8 and OR-in the new byte at the bottom,
+    /// then increments `bs_live` by 8.
+    fn bs_refill(&mut self) -> io::Result<()> {
+        let mut byte = [0u8; 1];
+        self.inner.read_exact(&mut byte)?;
+        self.bs_buff = (self.bs_buff << 8) | byte[0] as i32;
+        self.bs_live += 8;
+        Ok(())
+    }
+
+    /// Read a single bit (0 or 1).
+    fn bs_get_bit(&mut self) -> io::Result<i32> {
+        self.bs_get_bits(1)
+    }
+
+    /// Read `n` bits (1–24) and return them right-aligned in an `i32`.
+    ///
+    /// Refills from the inner reader one byte at a time until at least `n`
+    /// bits are available, then extracts the top `n` bits from the buffer.
+    ///
+    /// # Buffer layout
+    ///
+    /// ```text
+    ///  bs_buff (i32, 32 bits):
+    ///  ┌──────────────────────┬──────────────────────┐
+    ///  │  unused (high bits)  │  bs_live valid bits  │
+    ///  └──────────────────────┴──────────────────────┘
+    ///                          ↑                    ↑
+    ///                   bit (bs_live-1)            bit 0
+    ///
+    ///  Extract n bits:  (bs_buff >> (bs_live - n)) & ((1 << n) - 1)
+    /// ```
+    fn bs_get_bits(&mut self, n: i32) -> io::Result<i32> {
+        debug_assert!((1..=24).contains(&n));
+        while self.bs_live < n {
+            self.bs_refill()?;
+        }
+        let v = (self.bs_buff >> (self.bs_live - n)) & ((1 << n) - 1);
+        self.bs_live -= n;
+        Ok(v)
+    }
+
+    /// Read 32 bits as two 16-bit halves (mirrors `bs_put_int32` in the writer).
+    fn bs_get_int32(&mut self) -> io::Result<u32> {
+        let hi = self.bs_get_bits(16)? as u32;
+        let lo = self.bs_get_bits(16)? as u32;
+        Ok((hi << 16) | lo)
+    }
+
+    // -----------------------------------------------------------------------
+    // Block-level decode
+    // -----------------------------------------------------------------------
+
+    /// Read the 48-bit block or EOS magic number from the bit stream.
+    ///
+    /// Returns `true`  if a block magic (`0x314159265359`, π)  was found.
+    /// Returns `false` if the EOS magic  (`0x177245385090`, √π) was found.
+    /// Returns an error if neither matches (corrupt or truncated stream).
+    ///
+    /// The magic is read as six consecutive 8-bit values so that it works
+    /// correctly regardless of how many bits are currently buffered.
+    fn read_block_or_eos_magic(&mut self) -> io::Result<bool> {
+        // Read 48 bits as six bytes, MSB first.
+        let b0 = self.bs_get_bits(8)? as u8;
+        let b1 = self.bs_get_bits(8)? as u8;
+        let b2 = self.bs_get_bits(8)? as u8;
+        let b3 = self.bs_get_bits(8)? as u8;
+        let b4 = self.bs_get_bits(8)? as u8;
+        let b5 = self.bs_get_bits(8)? as u8;
+
+        // Block magic: 0x314159265359  (first six hex digits of π)
+        if b0 == 0x31 && b1 == 0x41 && b2 == 0x59
+            && b3 == 0x26 && b4 == 0x53 && b5 == 0x59
+        {
+            return Ok(true);
+        }
+
+        // EOS magic: 0x177245385090  (first six hex digits of √π)
+        if b0 == 0x17 && b1 == 0x72 && b2 == 0x45
+            && b3 == 0x38 && b4 == 0x50 && b5 == 0x90
+        {
+            return Ok(false);
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "bzip2: invalid block header magic",
+        ))
+    }
+
+    /// Read and decode the full block header, Huffman tables, and MTF data.
+    ///
+    /// On entry:  `current_state == StartBlock`.
+    /// On exit:   `current_state == RandPartA` (ready to emit bytes),
+    ///            or `NoProcess` if the EOS marker was seen.
+    ///
+    /// # Stream layout consumed here
+    ///
+    /// ```text
+    /// [48 bits]  block magic  0x314159265359  (π)
+    ///            — or —
+    ///            EOS magic    0x177245385090  (√π)  → end of stream
+    /// [32 bits]  stored block CRC
+    /// [ 1 bit ]  block_randomised flag
+    /// …          get_and_move_to_front_decode (orig_ptr + Huffman + MTF)
+    /// ```
+    fn init_block(&mut self) -> io::Result<()> {
+        let is_block = self.read_block_or_eos_magic()?;
+
+        if !is_block {
+            // EOS magic: read the combined stream CRC and verify.
+            self.stored_stream_crc = self.bs_get_int32()?;
+            self.end_stream()?;
+            self.current_state = ReaderState::NoProcess;
+            return Ok(());
+        }
+
+        // --- Block header ---
+        self.stored_block_crc = self.bs_get_int32()?;
+        self.block_randomised = self.bs_get_bit()? == 1;
+
+        // Reset randomisation state; the first step is taken in setup_rand_part_a.
+        self.r_n_to_go = 0;
+        self.r_t_pos  = 0;
+
+        // Decode Huffman tables, then decode the MTF-encoded symbol stream.
+        // Fills orig_ptr and the raw BWT bytes into tt[] (low 8 bits per entry).
+        self.get_and_move_to_front_decode()?;
+
+        // Build the BWT inverse chain (tt[] high bits) and set t_pos = tt[orig_ptr].
+        self.setup_block();
+
+        // Prepare per-block CRC accumulator.
+        self.block_crc.initialise();
+
+        self.current_state = ReaderState::RandPartA;
+        Ok(())
+    }
+
+    /// Read the in-use bitmap, selector list, and Huffman code lengths
+    /// from the stream; build the `limit`, `base`, and `perm` decode tables.
+    ///
+    /// # Stream layout consumed here
+    ///
+    /// ```text
+    /// [16 bits]  group-present bitmap  (which of the 16 × 16 groups are used)
+    /// [16 bits]  per-byte bitmap       (repeated for each present group)
+    /// [ 3 bits]  n_groups  (number of Huffman tables, 2–6)
+    /// [15 bits]  n_selectors
+    /// unary × n_selectors              selector MTF values
+    /// [5 bits] + deltas × n_groups     code lengths (delta-encoded per table)
+    /// ```
+    fn recv_decoding_tables(&mut self) -> io::Result<()> {
+        // --- In-use bitmap (256 bits, encoded as 16 groups of 16) ---
+        // The outer 16-bit word says which groups have any set bits.
+        let in_use16 = self.bs_get_bits(16)?;
+        let mut in_use = [false; 256];
+        for i in 0..16i32 {
+            if in_use16 & (1 << (15 - i)) != 0 {
+                let row = self.bs_get_bits(16)?;
+                for j in 0..16i32 {
+                    if row & (1 << (15 - j)) != 0 {
+                        in_use[(i * 16 + j) as usize] = true;
+                    }
+                }
+            }
+        }
+
+        self.n_in_use = 0;
+        for i in 0..256 {
+            self.in_use[i] = in_use[i];
+            if in_use[i] {
+                self.seq_to_unseq[self.n_in_use] = i as u8;
+                self.n_in_use += 1;
+            }
+        }
+
+        let alpha_size = self.n_in_use + 2; // +2 for RUNA and RUNB
+
+        // --- Number of Huffman tables and selectors ---
+        self.n_groups    = self.bs_get_bits(3)?  as usize;
+        self.n_selectors = self.bs_get_bits(15)? as usize;
+
+        // --- Selector list: unary-coded, each value is the MTF rank ---
+        // A unary value of k is stored as k 1-bits followed by one 0-bit.
+        for i in 0..self.n_selectors {
+            let mut rank = 0usize;
+            while self.bs_get_bit()? == 1 {
+                rank += 1;
+            }
+            self.selector_mtf[i] = rank as u8;
+        }
+
+        // MTF-decode the selectors: pos[] is the MTF alphabet (table indices).
+        let mut pos = [0u8; N_GROUPS];
+        for i in 0..N_GROUPS {
+            pos[i] = i as u8;
+        }
+        for i in 0..self.n_selectors {
+            let j = self.selector_mtf[i] as usize;
+            let tmp = pos[j];
+            // Shift pos[0..j] right by one, then insert tmp at front.
+            pos.copy_within(0..j, 1);
+            pos[0] = tmp;
+            self.selector[i] = tmp;
+        }
+
+        // --- Code lengths for each Huffman table (delta-encoded) ---
+        // Start value: 5 bits.  For each symbol: read bits until 0 is seen;
+        // each 1 followed by 0 decrements, each 1 followed by 1 increments.
+        let mut len = [[0i32; MAX_ALPHA_SIZE]; N_GROUPS];
+        for t in 0..self.n_groups {
+            let mut curr = self.bs_get_bits(5)?;
+            for i in 0..alpha_size {
+                loop {
+                    if self.bs_get_bit()? == 0 { break; }
+                    if self.bs_get_bit()? == 0 { curr += 1; }
+                    else                        { curr -= 1; }
+                }
+                len[t][i] = curr;
+            }
+        }
+
+        // --- Build Huffman decode tables (limit, base, perm) ---
+        for t in 0..self.n_groups {
+            let mut min_len = 32i32;
+            let mut max_len =  0i32;
+            for i in 0..alpha_size {
+                let l = len[t][i];
+                if l > max_len { max_len = l; }
+                if l < min_len { min_len = l; }
+            }
+            Self::hb_create_decode_tables(
+                &mut self.limit[t],
+                &mut self.base[t],
+                &mut self.perm[t],
+                &len[t],
+                min_len, max_len, alpha_size,
+            );
+            self.min_lens[t] = min_len;
+        }
+
+        Ok(())
+    }
+
+    /// Build canonical Huffman decode tables from an array of code lengths.
+    ///
+    /// Mirrors `HbCreateDecodeTables` from bc-csharp.
+    ///
+    /// * `perm`  — symbols in canonical (length-first) order.
+    /// * `base`  — base code value for each length level.
+    /// * `limit` — largest code value at each length level.
+    fn hb_create_decode_tables(
+        limit:  &mut [i32; MAX_CODE_LEN + 1],
+        base:   &mut [i32; MAX_CODE_LEN + 1],
+        perm:   &mut [i32; MAX_ALPHA_SIZE],
+        length: &[i32],
+        min_len: i32, max_len: i32, alpha_size: usize,
+    ) {
+        // perm[]: symbols listed in ascending code-length order (canonical order).
+        let mut pp = 0;
+        for i in min_len..=max_len {
+            for j in 0..alpha_size {
+                if length[j] == i {
+                    perm[pp] = j as i32;
+                    pp += 1;
+                }
+            }
+        }
+
+        // base[l]: cumulative count of symbols with length < l.
+        base.fill(0);
+        for i in 0..alpha_size {
+            base[length[i] as usize + 1] += 1;
+        }
+        for i in 1..=MAX_CODE_LEN {
+            base[i] += base[i - 1];
+        }
+
+        // limit[l]: the largest Huffman code value of length l.
+        limit.fill(0);
+        let mut vec = 0i32;
+        for i in min_len..=max_len {
+            vec += base[i as usize + 1] - base[i as usize];
+            limit[i as usize] = vec - 1;
+            vec <<= 1;
+        }
+
+        // Adjust base[] so that  symbol_index = perm[code - base[len]].
+        for i in (min_len + 1)..=max_len {
+            base[i as usize] =
+                ((limit[(i - 1) as usize] + 1) << 1) - base[i as usize];
+        }
+    }
+
+    /// Decode the MTF-encoded symbol stream using the Huffman tables.
+    ///
+    /// Reads `orig_ptr`, calls `recv_decoding_tables`, then decodes each
+    /// Huffman symbol and reverses the MTF transform, writing raw BWT bytes
+    /// into the low 8 bits of `tt[]`.  `unzftab[b]` accumulates how many
+    /// times byte `b` appears, ready for `setup_block` to use.
+    ///
+    /// After this call `self.count` holds the number of bytes in the block.
+    fn get_and_move_to_front_decode(&mut self) -> io::Result<()> {
+        self.orig_ptr = self.bs_get_bits(24)? as usize;
+        self.recv_decoding_tables()?;
+
+        let eob = self.n_in_use + 1; // end-of-block symbol index
+
+        // MTF alphabet: yy[rank] = the actual byte value for that rank.
+        // Initialised from seq_to_unseq which maps compact MTF indices to bytes.
+        let mut yy = [0u8; 256];
+        for i in 0..self.n_in_use {
+            yy[i] = self.seq_to_unseq[i];
+        }
+
+        self.unzftab = [0; 256];
+        let mut last: i32 = -1; // index of the last byte written into tt[]
+
+        // Huffman decode state — shared between the outer loop and the
+        // RUNA/RUNB inner loop via the get_next_sym! macro below.
+        let mut group_no:  i32 = -1;
+        let mut group_pos: i32 = 0;
+        let mut zt:  usize = 0;
+        let mut zn:  i32; // always assigned inside get_next_sym! before use
+        let mut zvec: i32; // always assigned inside get_next_sym! before use
+
+        // Fetch the next Huffman symbol.
+        // Advances group_no / group_pos when the current G_SIZE group is used up,
+        // then reads enough bits to decode one symbol from the selected table.
+        macro_rules! get_next_sym {
+            () => {{
+                if group_pos == 0 {
+                    group_no  += 1;
+                    group_pos  = G_SIZE as i32;
+                    zt = self.selector[group_no as usize] as usize;
+                }
+                group_pos -= 1;
+
+                zn   = self.min_lens[zt];
+                zvec = self.bs_get_bits(zn)?;
+                while zvec > self.limit[zt][zn as usize] {
+                    zn  += 1;
+                    zvec = (zvec << 1) | self.bs_get_bit()?;
+                }
+                self.perm[zt][(zvec - self.base[zt][zn as usize]) as usize]
+            }};
+        }
+
+        let mut next_sym = get_next_sym!();
+
+        loop {
+            if next_sym == eob as i32 {
+                break;
+            }
+
+            if next_sym == RUNA as i32 || next_sym == RUNB as i32 {
+                // Bijective base-2 run-length decode.
+                // Each RUNA adds `n`, each RUNB adds `2*n`, then n doubles.
+                // The run length is s+1 copies of yy[0].
+                let mut s: i32 = -1;
+                let mut n: i32 = 1;
+                loop {
+                    if next_sym == RUNA as i32 { s += n; }
+                    else                        { s += 2 * n; }
+                    n <<= 1;
+                    next_sym = get_next_sym!();
+                    if next_sym != RUNA as i32 && next_sym != RUNB as i32 {
+                        break;
+                    }
+                }
+                s += 1;
+                let ch = yy[0];
+                self.unzftab[ch as usize] += s as usize;
+                for _ in 0..s {
+                    last += 1;
+                    self.tt[last as usize] = ch as u32;
+                }
+                // next_sym already holds the symbol that ended the run;
+                // continue the outer loop without fetching again.
+            } else {
+                // MTF decode: symbol value encodes the rank (1-based).
+                last += 1;
+                let rank = (next_sym - 1) as usize;
+                let ch   = yy[rank];
+                // Move yy[rank] to the front: shift yy[0..rank] right by one.
+                yy.copy_within(0..rank, 1);
+                yy[0] = ch;
+                self.unzftab[ch as usize] += 1;
+                self.tt[last as usize] = ch as u32;
+                next_sym = get_next_sym!();
+            }
+        }
+
+        // Record the total number of bytes decoded in this block.
+        self.count = (last + 1) as usize;
+        Ok(())
+    }
+
+    /// Build the BWT inverse chain (`tt[]`) from `unzftab[]` and the raw
+    /// block bytes, and position `t_pos` at `orig_ptr`.
+    ///
+    /// After this call the block is ready for the RLE output pass.
+    ///
+    /// # Combined encoding of `tt[]`
+    ///
+    /// After this function returns, each entry encodes two values:
+    ///
+    /// ```text
+    ///  tt[j]  =  (byte_at_j << 24)  |  chain_j
+    ///             ───────────────────   ────────
+    ///             bits 31–24            bits 23–0
+    ///             BWT last-column       chain pointer: the BWT source
+    ///             byte at position j    position that sorts to rank j
+    /// ```
+    ///
+    /// The output loop in `setup_rand_part_a` uses:
+    /// ```text
+    ///  ch     = (tt[t_pos] >> 24) as u8
+    ///  t_pos  = (tt[t_pos] & 0x00_FF_FF_FF) as usize
+    /// ```
+    fn setup_block(&mut self) {
+        // tt[i] currently holds only the raw BWT byte in the low 8 bits
+        // (written by get_and_move_to_front_decode).  We need those bytes
+        // both as ll8[i] (to build the chain) and as ll8[j] (to pack into
+        // the high 8 bits at the chain destination j).  A temporary copy
+        // lets us read either without fighting the borrow checker.
+        let ll8: Vec<u8> = self.tt[..self.count]
+            .iter()
+            .map(|&v| v as u8)
+            .collect();
+
+        // cftab[b] = number of bytes with value < b (prefix sum of unzftab).
+        // cftab[b] is the starting sorted rank for byte value b, and is
+        // incremented as each source position is assigned a rank.
+        let mut cftab = [0usize; 257];
+        for i in 0..256 {
+            cftab[i + 1] = self.unzftab[i];
+        }
+        for i in 1..=256 {
+            cftab[i] += cftab[i - 1];
+        }
+
+        // Build the combined BWT inverse chain.
+        // For each source position i with byte value uc:
+        //   j = next available sorted rank for uc  (= cftab[uc])
+        //   tt[j] = (ll8[j] << 24) | i
+        //             ^               ^
+        //             byte at rank j  chain: rank j came from source i
+        for i in 0..self.count {
+            let uc  = ll8[i] as usize;
+            let j   = cftab[uc];
+            cftab[uc] += 1;
+            self.tt[j] = ((ll8[j] as u32) << 24) | (i as u32);
+        }
+
+        // Advance the walking pointer once: start at the chain pointer
+        // stored at orig_ptr (the low 24 bits), not at orig_ptr itself.
+        self.t_pos = (self.tt[self.orig_ptr] & 0x00_FF_FF_FF) as usize;
+
+        // Reset per-block output counters.
+        self.t_i           = 0;
+        self.j2            = 0;
+        self.current_char  = -1; // no byte pending (equivalent to ch2 = 256 in C#)
+    }
+
+    /// Verify the block CRC against `stored_block_crc` and fold it into
+    /// `computed_stream_crc`.  Returns an error on mismatch.
+    fn end_block(&mut self) -> io::Result<()> {
+        todo!()
+    }
+
+    /// Verify the stream CRC at EOS and mark the stream as finished.
+    fn end_stream(&mut self) -> io::Result<()> {
+        todo!()
+    }
+
+    // -----------------------------------------------------------------------
+    // RLE output state machine
+    // -----------------------------------------------------------------------
+
+    /// State A — fetch the next BWT character, begin a new RLE run.
+    ///
+    /// Advances `t_pos` through `tt[]`, applies randomisation if needed,
+    /// stores the character in `t_ch`, and transitions to `RandPartB`.
+    /// When the block is exhausted, calls `end_block` and transitions to
+    /// `StartBlock` (or `NoProcess` if this was the last block).
+    fn setup_rand_part_a(&mut self) -> io::Result<()> {
+        todo!()
+    }
+
+    /// State B — accumulate an RLE run.
+    ///
+    /// While successive characters equal `ch_prev`, increments `j2`.
+    /// At `j2 == 4` the fifth character is the repeat count; transitions
+    /// to `RandPartC`.  Otherwise sets `current_char` / `output_count`
+    /// and transitions back to `RandPartA`.
+    fn setup_rand_part_b(&mut self) -> io::Result<()> {
+        todo!()
+    }
+
+    /// State C — emit the run extension.
+    ///
+    /// Decrements `z`; when exhausted transitions back to `RandPartA`.
+    /// Sets `current_char` / `output_count` for the repeated byte.
+    fn setup_rand_part_c(&mut self) -> io::Result<()> {
+        todo!()
+    }
+}
+
+impl<R: Read> Read for BZip2Reader<R> {
+    /// Decompress bytes into `buf`, returning the number of bytes written.
+    ///
+    /// Returns `Ok(0)` at end-of-stream.
+    ///
+    /// # Internal flow
+    ///
+    /// ```text
+    /// while buf has space:
+    ///     drain pending output_count for current_char
+    ///     advance state machine → produces next current_char + output_count
+    ///         StartBlock  → init_block()
+    ///         RandPartA   → setup_rand_part_a()
+    ///         RandPartB   → setup_rand_part_b()
+    ///         RandPartC   → setup_rand_part_c()
+    ///         NoProcess   → stop (EOF)
+    /// ```
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let mut written = 0;
+
+        'fill: while written < buf.len() {
+            // Drain pending copies of current_char first.
+            while self.output_count > 0 {
+                if written >= buf.len() {
+                    break 'fill;
+                }
+                buf[written] = self.current_char as u8;
+                written += 1;
+                self.output_count -= 1;
+            }
+
+            // Advance the state machine to produce the next character.
+            match self.current_state {
+                ReaderState::StartBlock => self.init_block()?,
+                ReaderState::RandPartA  => self.setup_rand_part_a()?,
+                ReaderState::RandPartB  => self.setup_rand_part_b()?,
+                ReaderState::RandPartC  => self.setup_rand_part_c()?,
+                ReaderState::NoProcess  => break 'fill,
+            }
+        }
+
+        Ok(written)
+    }
+}

--- a/src/util/bzip2/bzip2_reader.rs
+++ b/src/util/bzip2/bzip2_reader.rs
@@ -23,6 +23,7 @@
 
 use std::io::{self, Read};
 
+use super::bzip2_writer::RNUMS;
 use super::constants::*;
 use super::crc::Crc;
 
@@ -69,8 +70,6 @@ pub struct BZip2Reader<R: Read> {
     inner: R,
 
     // --- Stream-level state ---
-    /// Compression level read from the stream header (1–9).
-    block_size_100k: usize,
     /// Set when the EOS marker has been seen and CRC verified.
     stream_end: bool,
 
@@ -194,7 +193,6 @@ impl<R: Read> BZip2Reader<R> {
 
         Ok(Self {
             inner,
-            block_size_100k,
             stream_end: false,
             bs_buff: 0,
             bs_live: 0,
@@ -409,9 +407,9 @@ impl<R: Read> BZip2Reader<R> {
         }
 
         self.n_in_use = 0;
-        for i in 0..256 {
-            self.in_use[i] = in_use[i];
-            if in_use[i] {
+        for (i, &used) in in_use.iter().enumerate() {
+            self.in_use[i] = used;
+            if used {
                 self.seq_to_unseq[self.n_in_use] = i as u8;
                 self.n_in_use += 1;
             }
@@ -435,8 +433,8 @@ impl<R: Read> BZip2Reader<R> {
 
         // MTF-decode the selectors: pos[] is the MTF alphabet (table indices).
         let mut pos = [0u8; N_GROUPS];
-        for i in 0..N_GROUPS {
-            pos[i] = i as u8;
+        for (i, p) in pos.iter_mut().enumerate() {
+            *p = i as u8;
         }
         for i in 0..self.n_selectors {
             let j = self.selector_mtf[i] as usize;
@@ -451,24 +449,23 @@ impl<R: Read> BZip2Reader<R> {
         // Start value: 5 bits.  For each symbol: read bits until 0 is seen;
         // each 1 followed by 0 decrements, each 1 followed by 1 increments.
         let mut len = [[0i32; MAX_ALPHA_SIZE]; N_GROUPS];
-        for t in 0..self.n_groups {
+        for len_t in len.iter_mut().take(self.n_groups) {
             let mut curr = self.bs_get_bits(5)?;
-            for i in 0..alpha_size {
+            for cell in len_t.iter_mut().take(alpha_size) {
                 loop {
                     if self.bs_get_bit()? == 0 { break; }
                     if self.bs_get_bit()? == 0 { curr += 1; }
                     else                        { curr -= 1; }
                 }
-                len[t][i] = curr;
+                *cell = curr;
             }
         }
 
         // --- Build Huffman decode tables (limit, base, perm) ---
-        for t in 0..self.n_groups {
+        for (t, len_t) in len.iter().enumerate().take(self.n_groups) {
             let mut min_len = 32i32;
             let mut max_len =  0i32;
-            for i in 0..alpha_size {
-                let l = len[t][i];
+            for &l in len_t.iter().take(alpha_size) {
                 if l > max_len { max_len = l; }
                 if l < min_len { min_len = l; }
             }
@@ -476,7 +473,7 @@ impl<R: Read> BZip2Reader<R> {
                 &mut self.limit[t],
                 &mut self.base[t],
                 &mut self.perm[t],
-                &len[t],
+                len_t,
                 min_len, max_len, alpha_size,
             );
             self.min_lens[t] = min_len;
@@ -502,8 +499,8 @@ impl<R: Read> BZip2Reader<R> {
         // perm[]: symbols listed in ascending code-length order (canonical order).
         let mut pp = 0;
         for i in min_len..=max_len {
-            for j in 0..alpha_size {
-                if length[j] == i {
+            for (j, &l) in length.iter().enumerate().take(alpha_size) {
+                if l == i {
                     perm[pp] = j as i32;
                     pp += 1;
                 }
@@ -512,8 +509,8 @@ impl<R: Read> BZip2Reader<R> {
 
         // base[l]: cumulative count of symbols with length < l.
         base.fill(0);
-        for i in 0..alpha_size {
-            base[length[i] as usize + 1] += 1;
+        for &l in length.iter().take(alpha_size) {
+            base[l as usize + 1] += 1;
         }
         for i in 1..=MAX_CODE_LEN {
             base[i] += base[i - 1];
@@ -552,9 +549,7 @@ impl<R: Read> BZip2Reader<R> {
         // MTF alphabet: yy[rank] = the actual byte value for that rank.
         // Initialised from seq_to_unseq which maps compact MTF indices to bytes.
         let mut yy = [0u8; 256];
-        for i in 0..self.n_in_use {
-            yy[i] = self.seq_to_unseq[i];
-        }
+        yy[..self.n_in_use].copy_from_slice(&self.seq_to_unseq[..self.n_in_use]);
 
         self.unzftab = [0; 256];
         let mut last: i32 = -1; // index of the last byte written into tt[]
@@ -676,9 +671,7 @@ impl<R: Read> BZip2Reader<R> {
         // cftab[b] is the starting sorted rank for byte value b, and is
         // incremented as each source position is assigned a rank.
         let mut cftab = [0usize; 257];
-        for i in 0..256 {
-            cftab[i + 1] = self.unzftab[i];
-        }
+        cftab[1..257].copy_from_slice(&self.unzftab);
         for i in 1..=256 {
             cftab[i] += cftab[i - 1];
         }
@@ -709,12 +702,29 @@ impl<R: Read> BZip2Reader<R> {
     /// Verify the block CRC against `stored_block_crc` and fold it into
     /// `computed_stream_crc`.  Returns an error on mismatch.
     fn end_block(&mut self) -> io::Result<()> {
-        todo!()
+        let block_final_crc = self.block_crc.get_final();
+        if block_final_crc != self.stored_block_crc {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "bzip2: block CRC mismatch",
+            ));
+        }
+        // Same accumulation formula used by BZip2Writer::end_block.
+        self.computed_stream_crc =
+            self.computed_stream_crc.rotate_left(1) ^ block_final_crc;
+        Ok(())
     }
 
     /// Verify the stream CRC at EOS and mark the stream as finished.
     fn end_stream(&mut self) -> io::Result<()> {
-        todo!()
+        if self.computed_stream_crc != self.stored_stream_crc {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "bzip2: stream CRC mismatch",
+            ));
+        }
+        self.stream_end = true;
+        Ok(())
     }
 
     // -----------------------------------------------------------------------
@@ -728,7 +738,38 @@ impl<R: Read> BZip2Reader<R> {
     /// When the block is exhausted, calls `end_block` and transitions to
     /// `StartBlock` (or `NoProcess` if this was the last block).
     fn setup_rand_part_a(&mut self) -> io::Result<()> {
-        todo!()
+        if self.t_i >= self.count {
+            self.end_block()?;
+            self.current_state = ReaderState::StartBlock;
+            return Ok(());
+        }
+
+        // Save previous character for run detection in state B.
+        self.ch_prev = self.t_ch;
+
+        // Advance the BWT walking pointer and extract the byte.
+        //   tt[t_pos] = (byte_at_t_pos << 24) | next_t_pos
+        let combined = self.tt[self.t_pos];
+        self.t_ch = (combined >> 24) as u8;
+        self.t_pos = (combined & 0x00_FF_FF_FF) as usize;
+
+        // De-randomise: apply the same flip pattern the writer used.
+        // r_n_to_go starts at 0; when it hits 0, reload from RNUMS[r_t_pos]
+        // and advance r_t_pos.  After decrementing, XOR bit 0 when r_n_to_go == 1.
+        if self.block_randomised {
+            if self.r_n_to_go == 0 {
+                self.r_n_to_go = RNUMS[self.r_t_pos] as i32;
+                self.r_t_pos = (self.r_t_pos + 1) & 0x1FF;
+            }
+            self.r_n_to_go -= 1;
+            if self.r_n_to_go == 1 {
+                self.t_ch ^= 1;
+            }
+        }
+
+        self.t_i += 1;
+        self.current_state = ReaderState::RandPartB;
+        Ok(())
     }
 
     /// State B — accumulate an RLE run.
@@ -738,7 +779,34 @@ impl<R: Read> BZip2Reader<R> {
     /// to `RandPartC`.  Otherwise sets `current_char` / `output_count`
     /// and transitions back to `RandPartA`.
     fn setup_rand_part_b(&mut self) -> io::Result<()> {
-        todo!()
+        if self.j2 == 4 {
+            // t_ch is the repeat-count byte (the byte A just read after seeing
+            // four identical characters).  It is a control byte — not emitted
+            // as data and not counted in the CRC.
+            self.z = self.t_ch as i32;
+            self.j2 = 0;
+            self.current_state = if self.z > 0 {
+                ReaderState::RandPartC
+            } else {
+                ReaderState::RandPartA
+            };
+        } else if self.t_ch == self.ch_prev && self.j2 > 0 {
+            // Same character as the previous one: extend the run.
+            self.j2 += 1;
+            self.block_crc.update(self.t_ch);
+            self.current_char = self.t_ch as i32;
+            self.output_count = 1;
+            self.current_state = ReaderState::RandPartA;
+        } else {
+            // New character (or first character of the block: j2 == 0).
+            // Begin a fresh run of length 1.
+            self.j2 = 1;
+            self.block_crc.update(self.t_ch);
+            self.current_char = self.t_ch as i32;
+            self.output_count = 1;
+            self.current_state = ReaderState::RandPartA;
+        }
+        Ok(())
     }
 
     /// State C — emit the run extension.
@@ -746,7 +814,14 @@ impl<R: Read> BZip2Reader<R> {
     /// Decrements `z`; when exhausted transitions back to `RandPartA`.
     /// Sets `current_char` / `output_count` for the repeated byte.
     fn setup_rand_part_c(&mut self) -> io::Result<()> {
-        todo!()
+        self.block_crc.update(self.ch_prev);
+        self.current_char = self.ch_prev as i32;
+        self.output_count = 1;
+        self.z -= 1;
+        if self.z == 0 {
+            self.current_state = ReaderState::RandPartA;
+        }
+        Ok(())
     }
 }
 
@@ -796,5 +871,155 @@ impl<R: Read> Read for BZip2Reader<R> {
         }
 
         Ok(written)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::{Read, Write};
+
+    use super::super::bzip2_writer::BZip2Writer;
+    use super::BZip2Reader;
+
+    /// Compress `data` with BZip2Writer at the given block size, then return
+    /// the raw compressed bytes.
+    fn compress(data: &[u8], block_size: usize) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut w = BZip2Writer::with_block_size(&mut buf, block_size).unwrap();
+            w.write_all(data).unwrap();
+            w.finish().unwrap();
+        } // drop w, releasing the borrow on buf
+        buf
+    }
+
+    /// Decompress a bzip2 byte slice and return the original bytes.
+    fn decompress(compressed: &[u8]) -> Vec<u8> {
+        let mut r = BZip2Reader::new(compressed).unwrap();
+        let mut out = Vec::new();
+        r.read_to_end(&mut out).unwrap();
+        out
+    }
+
+    /// Round-trip `data` and assert it survives unchanged.
+    fn round_trip(data: &[u8], block_size: usize) {
+        let compressed = compress(data, block_size);
+        let got = decompress(&compressed);
+        assert_eq!(got, data, "round-trip failed for {} bytes", data.len());
+    }
+
+    // --- basic cases ---
+
+    #[test]
+    fn empty_input() {
+        round_trip(b"", 9);
+    }
+
+    #[test]
+    fn single_byte() {
+        round_trip(b"A", 9);
+    }
+
+    #[test]
+    fn short_ascii() {
+        round_trip(b"Hello, world!", 9);
+    }
+
+    #[test]
+    fn all_byte_values() {
+        let data: Vec<u8> = (0u8..=255).collect();
+        round_trip(&data, 9);
+    }
+
+    // --- RLE corner cases ---
+
+    /// Exactly 4 identical bytes: triggers the run-length path with count = 0
+    /// (no extra copies beyond the 4).
+    #[test]
+    fn run_of_exactly_4() {
+        round_trip(&[0xA5u8; 4], 9);
+    }
+
+    /// 5 identical bytes: count byte = 1 (one extra beyond 4).
+    #[test]
+    fn run_of_5() {
+        round_trip(&[0xA5u8; 5], 9);
+    }
+
+    /// 259 identical bytes: count byte = 255 (maximum extra copies beyond 4).
+    #[test]
+    fn run_of_259() {
+        round_trip(&[0xFFu8; 259], 9);
+    }
+
+    /// Two back-to-back runs of 4+ identical bytes with a different byte between
+    /// them, exercising the run-counter reset path.
+    #[test]
+    fn two_runs_separated() {
+        let mut data = vec![b'A'; 8];
+        data.push(b'B');
+        data.extend_from_slice(&[b'C'; 8]);
+        round_trip(&data, 9);
+    }
+
+    // --- block size variants ---
+
+    #[test]
+    fn block_size_1() {
+        round_trip(b"block size one test", 1);
+    }
+
+    #[test]
+    fn block_size_9() {
+        round_trip(b"block size nine test", 9);
+    }
+
+    /// Data larger than a single block at block_size=1 (100 000 bytes), forcing
+    /// the reader through multiple block boundaries.
+    #[test]
+    fn multi_block() {
+        let data: Vec<u8> = (0u8..=255).cycle().take(120_000).collect();
+        round_trip(&data, 1);
+    }
+
+    // --- small-buffer reads ---
+
+    /// Read decompressed output one byte at a time to exercise the
+    /// `output_count` drain loop in every possible state.
+    #[test]
+    fn read_one_byte_at_a_time() {
+        let data = b"one byte at a time";
+        let compressed = compress(data, 9);
+        let mut r = BZip2Reader::new(compressed.as_slice()).unwrap();
+        let mut out = Vec::new();
+        let mut byte = [0u8; 1];
+        loop {
+            let n = r.read(&mut byte).unwrap();
+            if n == 0 {
+                break;
+            }
+            out.push(byte[0]);
+        }
+        assert_eq!(out, data);
+    }
+
+    // --- error cases ---
+
+    #[test]
+    fn bad_magic_returns_error() {
+        match BZip2Reader::new(b"notbzip2data".as_ref()) {
+            Err(e) => assert_eq!(e.kind(), std::io::ErrorKind::InvalidData),
+            Ok(_)  => panic!("expected an error for invalid magic"),
+        }
+    }
+
+    #[test]
+    fn truncated_stream_returns_error() {
+        let compressed = compress(b"some data", 9);
+        // Feed only the first half of the compressed stream.
+        let half = &compressed[..compressed.len() / 2];
+        let mut r = BZip2Reader::new(half).unwrap();
+        let result = r.read_to_end(&mut Vec::new());
+        assert!(result.is_err());
     }
 }

--- a/src/util/bzip2/bzip2_writer.rs
+++ b/src/util/bzip2/bzip2_writer.rs
@@ -1,0 +1,1486 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package is based on the work done by Keiron Liddle, Aftex Software
+// <keiron@aftexsw.com> to whom the Ant project is very grateful for his
+// great code.
+
+//! BZip2 compression writer.
+//!
+//! Port of `CBZip2OutputStream.cs` from bc-csharp.
+
+use std::io::{self, Write};
+
+use super::constants::*;
+use super::crc::Crc;
+
+/// Random number table used to randomize blocks that fail to sort efficiently.
+/// Shared with [`super::bzip2_reader`] (equivalent to C#'s `internal static`).
+pub(super) const RNUMS: [u16; 512] = [
+    619, 720, 127, 481, 931, 816, 813, 233, 566, 247, 985, 724, 205, 454, 863, 491, 741, 242, 949,
+    214, 733, 859, 335, 708, 621, 574, 73, 654, 730, 472, 419, 436, 278, 496, 867, 210, 399, 680,
+    480, 51, 878, 465, 811, 169, 869, 675, 611, 697, 867, 561, 862, 687, 507, 283, 482, 129, 807,
+    591, 733, 623, 150, 238, 59, 379, 684, 877, 625, 169, 643, 105, 170, 607, 520, 932, 727, 476,
+    693, 425, 174, 647, 73, 122, 335, 530, 442, 853, 695, 249, 445, 515, 909, 545, 703, 919, 874,
+    474, 882, 500, 594, 612, 641, 801, 220, 162, 819, 984, 589, 513, 495, 799, 161, 604, 958, 533,
+    221, 400, 386, 867, 600, 782, 382, 596, 414, 171, 516, 375, 682, 485, 911, 276, 98, 553, 163,
+    354, 666, 933, 424, 341, 533, 870, 227, 730, 475, 186, 263, 647, 537, 686, 600, 224, 469, 68,
+    770, 919, 190, 373, 294, 822, 808, 206, 184, 943, 795, 384, 383, 461, 404, 758, 839, 887, 715,
+    67, 618, 276, 204, 918, 873, 777, 604, 560, 951, 160, 578, 722, 79, 804, 96, 409, 713, 940,
+    652, 934, 970, 447, 318, 353, 859, 672, 112, 785, 645, 863, 803, 350, 139, 93, 354, 99, 820,
+    908, 609, 772, 154, 274, 580, 184, 79, 626, 630, 742, 653, 282, 762, 623, 680, 81, 927, 626,
+    789, 125, 411, 521, 938, 300, 821, 78, 343, 175, 128, 250, 170, 774, 972, 275, 999, 639, 495,
+    78, 352, 126, 857, 956, 358, 619, 580, 124, 737, 594, 701, 612, 669, 112, 134, 694, 363, 992,
+    809, 743, 168, 974, 944, 375, 748, 52, 600, 747, 642, 182, 862, 81, 344, 805, 988, 739, 511,
+    655, 814, 334, 249, 515, 897, 955, 664, 981, 649, 113, 974, 459, 893, 228, 433, 837, 553, 268,
+    926, 240, 102, 654, 459, 51, 686, 754, 806, 760, 493, 403, 415, 394, 687, 700, 946, 670, 656,
+    610, 738, 392, 760, 799, 887, 653, 978, 321, 576, 617, 626, 502, 894, 679, 243, 440, 680, 879,
+    194, 572, 640, 724, 926, 56, 204, 700, 707, 151, 457, 449, 797, 195, 791, 558, 945, 679, 297,
+    59, 87, 824, 713, 663, 412, 693, 342, 606, 134, 108, 571, 364, 631, 212, 174, 643, 304, 329,
+    343, 97, 430, 751, 497, 314, 983, 374, 822, 928, 140, 206, 73, 263, 980, 736, 876, 478, 430,
+    305, 170, 514, 364, 692, 829, 82, 855, 953, 676, 246, 369, 970, 294, 750, 807, 827, 150, 790,
+    288, 923, 804, 378, 215, 828, 592, 281, 565, 555, 710, 82, 896, 831, 547, 261, 524, 462, 293,
+    465, 502, 56, 661, 821, 976, 991, 658, 869, 905, 758, 745, 193, 768, 550, 608, 933, 378, 286,
+    215, 979, 792, 961, 61, 688, 793, 644, 986, 403, 106, 366, 905, 644, 372, 567, 466, 434, 645,
+    210, 389, 550, 919, 135, 780, 773, 635, 389, 707, 100, 626, 958, 165, 504, 920, 176, 193, 713,
+    857, 265, 203, 50, 668, 108, 645, 990, 626, 197, 510, 357, 358, 850, 858, 364, 936, 638,
+];
+
+/// Shell sort increment sequence (Knuth's increments).
+const INCS: [i32; 14] = [
+    1, 4, 13, 40, 121, 364, 1093, 3280, 9841, 29524, 88573, 265720, 797161, 2391484,
+];
+
+const SET_MARK: i32 = 1 << 21;
+const CLEAR_MASK: i32 = !SET_MARK;
+const GREATER_ICOST: u8 = 15;
+const LESSER_ICOST: u8 = 0;
+const SMALL_THRESH: i32 = 20;
+const DEPTH_THRESH: i32 = 10;
+
+/// BZip2 compression writer.
+///
+/// Wraps an inner [`Write`] and compresses data into the bzip2 format.
+/// Call [`BZip2Writer::finish`] when done to flush all remaining data and
+/// write the end-of-stream marker. Dropping without calling `finish` will
+/// attempt a best-effort flush but any I/O errors will be silently ignored.
+pub struct BZip2Writer<W: Write> {
+    inner: W,
+    finished: bool,
+
+    // --- Block state ---
+    /// Number of bytes currently in the block (1-based index into block_bytes).
+    count: usize,
+    /// Index in zptr[] of the original string after BWT sorting.
+    orig_ptr: usize,
+    /// Maximum count before the block must be flushed (block size - 20 bytes safety margin).
+    allowable_block_size: usize,
+    /// Whether the current block was randomised (to avoid worst-case sort behaviour).
+    block_randomised: bool,
+
+    // --- Bit output buffer ---
+    /// Accumulated bits waiting to be written; MSB is written first.
+    bs_buff: i32,
+    /// Number of free bit positions remaining in bs_buff (counts down from 32).
+    bs_live_pos: i32,
+
+    // --- CRC ---
+    block_crc: Crc,
+    stream_crc: u32,
+
+    // --- Symbol / alphabet tracking ---
+    /// Which byte values appear in the current block.
+    in_use: [bool; 256],
+    /// Number of distinct byte values in use.
+    n_in_use: usize,
+
+    // --- Huffman selectors ---
+    /// Which Huffman table to use for each G_SIZE-symbol group.
+    selectors: Vec<u8>, // MAX_SELECTORS entries
+
+    // --- Block buffers (allocated once based on block_size_100k) ---
+    /// Input block data (1-based; index 0 is a sentinel copy of the last byte).
+    block_bytes: Vec<u8>, // n + 1 + NUM_OVERSHOOT_BYTES
+    /// Quadrant values used to break ties during BWT suffix comparison.
+    quadrant_shorts: Vec<u16>, // n + 1 + NUM_OVERSHOOT_BYTES
+    /// Suffix-array permutation produced by block sorting.
+    /// Also reused as szptr (MTF output) since szptr values fit in i32.
+    zptr: Vec<i32>, // n entries
+    /// Frequency table for radix sort (65537 entries).
+    ftab: Vec<i32>,
+
+    // --- MTF (Move-To-Front) state ---
+    /// Total number of MTF-encoded symbols written.
+    n_mtf: usize,
+    /// Per-symbol frequency counts after MTF transform.
+    mtf_freq: Vec<i32>, // MAX_ALPHA_SIZE entries
+
+    // --- Block sorting control ---
+    work_factor: i32,
+    work_done: i32,
+    work_limit: i32,
+    first_attempt: bool,
+    /// Explicit stack for QSort3 to avoid system stack overflow on deep recursion.
+    block_sort_stack: Vec<(i32, i32, i32)>, // (ll, hh, dd)
+
+    // --- RLE input state ---
+    /// The byte value currently being accumulated, or None if no run is active.
+    current_byte: Option<u8>,
+    /// Length of the current run.
+    run_length: usize,
+}
+
+impl<W: Write> BZip2Writer<W> {
+    /// Create a new BZip2 writer with compression level 9 (maximum).
+    pub fn new(inner: W) -> io::Result<Self> {
+        Self::with_block_size(inner, 9)
+    }
+
+    /// Create a new BZip2 writer with a given block size (1–9).
+    /// Higher values give better compression at the cost of more memory.
+    pub fn with_block_size(mut inner: W, block_size: usize) -> io::Result<Self> {
+        let block_size_100k = block_size.clamp(1, 9);
+        let n = BASE_BLOCK_SIZE * block_size_100k;
+        let allowable_block_size = n - 20;
+
+        // Write stream header: "BZh" + block size digit
+        inner.write_all(&[b'B', b'Z', b'h', b'0' + block_size_100k as u8])?;
+
+        let mut writer = Self {
+            inner,
+            finished: false,
+            count: 0,
+            orig_ptr: 0,
+            allowable_block_size,
+            block_randomised: false,
+            bs_buff: 0,
+            bs_live_pos: 32,
+            block_crc: Crc::new(),
+            stream_crc: 0,
+            in_use: [false; 256],
+            n_in_use: 0,
+            selectors: vec![0u8; MAX_SELECTORS],
+            block_bytes: vec![0u8; n + 1 + NUM_OVERSHOOT_BYTES],
+            quadrant_shorts: vec![0u16; n + 1 + NUM_OVERSHOOT_BYTES],
+            zptr: vec![0i32; n],
+            ftab: vec![0i32; 65537],
+            n_mtf: 0,
+            mtf_freq: vec![0i32; MAX_ALPHA_SIZE],
+            work_factor: 50,
+            work_done: 0,
+            work_limit: 0,
+            first_attempt: false,
+            block_sort_stack: Vec::new(),
+            current_byte: None,
+            run_length: 0,
+        };
+
+        writer.init_block();
+        Ok(writer)
+    }
+}
+
+impl<W: Write> BZip2Writer<W> {
+    fn init_block(&mut self) {
+        self.block_crc.initialise();
+        self.count = 0;
+        self.in_use = [false; 256];
+    }
+
+    /// Flush all remaining data and write the end-of-stream marker.
+    ///
+    /// Must be called explicitly to ensure the compressed output is complete.
+    /// Dropping the writer will attempt this automatically, but any I/O errors
+    /// will be silently ignored.
+    pub fn finish(&mut self) -> io::Result<()> {
+        if self.finished {
+            return Ok(());
+        }
+        if self.run_length > 0 {
+            self.write_run()?;
+        }
+        self.current_byte = None;
+        if self.count > 0 {
+            self.end_block()?;
+        }
+        self.end_compression()?;
+        self.finished = true;
+        self.inner.flush()
+    }
+
+    fn write_byte_internal(&mut self, value: u8) -> io::Result<()> {
+        if self.current_byte == Some(value) {
+            self.run_length += 1;
+            if self.run_length > 254 {
+                self.write_run()?;
+                self.current_byte = None;
+                self.run_length = 0;
+            }
+        } else {
+            if self.current_byte.is_some() {
+                self.write_run()?;
+            }
+            self.current_byte = Some(value);
+            self.run_length = 1;
+        }
+        Ok(())
+    }
+
+    fn write_run(&mut self) -> io::Result<()> {
+        if self.count > self.allowable_block_size {
+            self.end_block()?;
+            self.init_block();
+        }
+
+        let ch = self.current_byte.expect("write_run called with no current byte");
+        self.in_use[ch as usize] = true;
+
+        match self.run_length {
+            1 => {
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.block_crc.update(ch);
+            }
+            2 => {
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.block_crc.update(ch);
+                self.block_crc.update(ch);
+            }
+            3 => {
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.block_crc.update(ch);
+                self.block_crc.update(ch);
+                self.block_crc.update(ch);
+            }
+            run_length => {
+                let repeat = run_length - 4;
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.count += 1;
+                self.block_bytes[self.count] = ch;
+                self.count += 1;
+                self.block_bytes[self.count] = repeat as u8;
+                self.in_use[repeat] = true;
+                self.block_crc.update_run(ch, run_length);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn end_block(&mut self) -> io::Result<()> {
+        let block_final_crc = self.block_crc.get_final();
+        self.stream_crc = self.stream_crc.rotate_left(1) ^ block_final_crc;
+
+        self.do_reversible_transformation()?;
+
+        // 48-bit block header magic: 0x314159265359 (pi)
+        self.bs_put_long48(0x314159265359u64)?;
+        self.bs_put_int32(block_final_crc)?;
+        self.bs_put_bit(if self.block_randomised { 1 } else { 0 })?;
+
+        self.move_to_front_code_and_send()
+    }
+
+    fn do_reversible_transformation(&mut self) -> io::Result<()> {
+        self.work_limit = self.work_factor * (self.count as i32 - 1);
+        self.work_done = 0;
+        self.block_randomised = false;
+        self.first_attempt = true;
+
+        self.main_sort();
+
+        if self.work_done > self.work_limit && self.first_attempt {
+            self.randomise_block();
+            self.work_limit = 0;
+            self.work_done = 0;
+            self.block_randomised = true;
+            self.first_attempt = false;
+            self.main_sort();
+        }
+
+        // Find the position of the original string in the sorted order (origPtr).
+        self.orig_ptr = (0..self.count)
+            .find(|&i| self.zptr[i] == 0)
+            .ok_or_else(|| io::Error::other("BWT: original string not found after sorting"))?;
+
+        Ok(())
+    }
+
+    fn main_sort(&mut self) {
+        let count = self.count;
+
+        // Set up overshoot area: copy first NUM_OVERSHOOT_BYTES bytes to end of block.
+        for i in 0..NUM_OVERSHOOT_BYTES {
+            self.block_bytes[count + i + 1] = self.block_bytes[(i % count) + 1];
+        }
+        for i in 0..=(count + NUM_OVERSHOOT_BYTES) {
+            self.quadrant_shorts[i] = 0;
+        }
+        // Sentinel: index 0 mirrors the last byte so comparisons wrap correctly.
+        self.block_bytes[0] = self.block_bytes[count];
+
+        if count <= 4000 {
+            self.main_sort_small();
+        } else {
+            self.main_sort_large();
+        }
+    }
+
+    /// Sort small blocks (count <= 4000) using Shell sort.
+    /// Lower constant overhead makes it faster than the full radix+QSort3 pipeline.
+    fn main_sort_small(&mut self) {
+        let count = self.count;
+        for i in 0..count {
+            self.zptr[i] = i as i32;
+        }
+        self.first_attempt = false;
+        self.work_done = 0;
+        self.work_limit = 0;
+        self.simple_sort(0, count as i32 - 1, 0);
+    }
+
+    /// Sort large blocks (count > 4000) using radix sort + QSort3.
+    fn main_sort_large(&mut self) {
+        let running_order = self.main_sort_radix();
+        self.main_sort_bucket_loop(running_order);
+    }
+
+    /// Radix sort phase: build 2-gram frequency table, place suffixes into
+    /// initial bucket positions, then sort buckets by size (smallest first).
+    /// Returns the running order array for use in the bucket loop.
+    fn main_sort_radix(&mut self) -> [i32; 256] {
+        let count = self.count;
+
+        // Build 2-gram frequency table.
+        self.ftab.fill(0);
+        let mut c1 = self.block_bytes[0] as usize;
+        for i in 1..=count {
+            let c2 = self.block_bytes[i] as usize;
+            self.ftab[(c1 << 8) + c2] += 1;
+            c1 = c2;
+        }
+
+        // Prefix-sum to get bucket start positions.
+        for i in 0..65536 {
+            self.ftab[i + 1] += self.ftab[i];
+        }
+
+        // Place each suffix into its initial bucket position.
+        c1 = self.block_bytes[1] as usize;
+        for i in 0..(count - 1) {
+            let c2 = self.block_bytes[i + 2] as usize;
+            let j = (c1 << 8) + c2;
+            c1 = c2;
+            self.ftab[j] -= 1;
+            self.zptr[self.ftab[j] as usize] = i as i32;
+        }
+        let j = (self.block_bytes[count] as usize) << 8 | self.block_bytes[1] as usize;
+        self.ftab[j] -= 1;
+        self.zptr[self.ftab[j] as usize] = count as i32 - 1;
+
+        // Sort big buckets by size (smallest first) using Shell sort.
+        let mut running_order = [0i32; 256];
+        for i in 0..256 {
+            running_order[i] = i as i32;
+        }
+        let mut h = 1i32;
+        while h <= 256 {
+            h = 3 * h + 1;
+        }
+        loop {
+            h /= 3;
+            for i in h as usize..256 {
+                let vv = running_order[i];
+                let mut j = i;
+                while self.ftab[((running_order[j - h as usize] + 1) as usize) << 8]
+                    - self.ftab[(running_order[j - h as usize] as usize) << 8]
+                    > self.ftab[((vv + 1) as usize) << 8] - self.ftab[(vv as usize) << 8]
+                {
+                    running_order[j] = running_order[j - h as usize];
+                    j -= h as usize;
+                    if j < h as usize {
+                        break;
+                    }
+                }
+                running_order[j] = vv;
+            }
+            if h == 1 {
+                break;
+            }
+        }
+
+        running_order
+    }
+
+    /// Bucket loop phase: QSort3 each small bucket, update quadrant values,
+    /// and synthesise sorted order for cross-bucket entries.
+    fn main_sort_bucket_loop(&mut self, running_order: [i32; 256]) {
+        let count = self.count;
+        let mut copy = [0i32; 256];
+        let mut big_done = [false; 256];
+
+        for i in 0..256usize {
+            let ss = running_order[i] as usize;
+
+            // QSort3 any unsorted small buckets [ss, j].
+            for j in 0..256usize {
+                let sb = (ss << 8) + j;
+                if (self.ftab[sb] & SET_MARK) != SET_MARK {
+                    let lo = self.ftab[sb] & CLEAR_MASK;
+                    let hi = (self.ftab[sb + 1] & CLEAR_MASK) - 1;
+                    if hi > lo {
+                        self.q_sort3(lo, hi, 2);
+                        if self.work_done > self.work_limit && self.first_attempt {
+                            return;
+                        }
+                    }
+                    self.ftab[sb] |= SET_MARK;
+                }
+            }
+
+            big_done[ss] = true;
+
+            // Update quadrant values for the completed big bucket.
+            if i < 255 {
+                let bb_start = (self.ftab[ss << 8] & CLEAR_MASK) as usize;
+                let bb_size = (self.ftab[(ss + 1) << 8] & CLEAR_MASK) as usize - bb_start;
+
+                let mut shifts = 0u32;
+                while (bb_size >> shifts) > 65534 {
+                    shifts += 1;
+                }
+                for j in 0..bb_size {
+                    let a2update = self.zptr[bb_start + j] as usize + 1;
+                    let q_val = (j >> shifts) as u16;
+                    self.quadrant_shorts[a2update] = q_val;
+                    if a2update <= NUM_OVERSHOOT_BYTES {
+                        self.quadrant_shorts[a2update + count] = q_val;
+                    }
+                }
+                debug_assert!(((bb_size.saturating_sub(1)) >> shifts) <= 65535);
+            }
+
+            // Synthesise sorted order for small buckets [t, ss] for all t != ss.
+            for j in 0..256usize {
+                copy[j] = self.ftab[(j << 8) + ss] & CLEAR_MASK;
+            }
+            for j in (self.ftab[ss << 8] & CLEAR_MASK) as usize
+                ..(self.ftab[(ss + 1) << 8] & CLEAR_MASK) as usize
+            {
+                let zptr_j = self.zptr[j] as usize;
+                let c1 = self.block_bytes[zptr_j] as usize;
+                if !big_done[c1] {
+                    self.zptr[copy[c1] as usize] =
+                        (if zptr_j == 0 { count } else { zptr_j }) as i32 - 1;
+                    copy[c1] += 1;
+                }
+            }
+            for j in 0..256usize {
+                self.ftab[(j << 8) + ss] |= SET_MARK;
+            }
+        }
+    }
+
+    /// Shell sort on `zptr[lo..=hi]`, comparing suffixes starting at depth `d`.
+    ///
+    /// Used for small sub-ranges (≤ [`SMALL_THRESH`]) and when [`q_sort3`]
+    /// exceeds [`DEPTH_THRESH`] recursion depth. Three elements are processed
+    /// per outer iteration (loop unrolling) to reduce branch overhead.
+    fn simple_sort(&mut self, lo: i32, hi: i32, d: i32) {
+        let big_n = hi - lo + 1;
+        if big_n < 2 {
+            return;
+        }
+
+        // Find the largest Shell sort increment smaller than big_n.
+        // partition_point returns the first index where INCS[i] >= big_n.
+        // Since big_n >= 2 > INCS[0]=1, the result is always >= 1.
+        let hp = INCS.partition_point(|&inc| inc < big_n) as i32 - 1;
+
+        // Outer loop: shrink the increment from largest to 1 (standard Shell sort).
+        let mut hp = hp;
+        while hp >= 0 {
+            let h = INCS[hp as usize];
+
+            // Inner loop: insertion sort with gap h.
+            // Processes 3 elements per iteration to reduce loop-control overhead.
+            let mut i = lo + h;
+            while i <= hi {
+                // --- element 1 ---
+                // Save the suffix index to insert, then shift elements right
+                // until we find the correct position.
+                let v = self.zptr[i as usize];
+                let mut j = i;
+                loop {
+                    // Read zptr[j-h] before calling full_gt_u (borrow checker:
+                    // cannot hold &self.zptr reference across a &mut self call).
+                    let zptr_jh = self.zptr[(j - h) as usize];
+                    if !self.full_gt_u(zptr_jh + d, v + d) {
+                        break;
+                    }
+                    self.zptr[j as usize] = zptr_jh;
+                    j -= h;
+                    if j <= lo + h - 1 {
+                        break;
+                    }
+                }
+                self.zptr[j as usize] = v;
+
+                // --- element 2 ---
+                i += 1;
+                if i > hi {
+                    break;
+                }
+                let v = self.zptr[i as usize];
+                let mut j = i;
+                loop {
+                    let zptr_jh = self.zptr[(j - h) as usize];
+                    if !self.full_gt_u(zptr_jh + d, v + d) {
+                        break;
+                    }
+                    self.zptr[j as usize] = zptr_jh;
+                    j -= h;
+                    if j <= lo + h - 1 {
+                        break;
+                    }
+                }
+                self.zptr[j as usize] = v;
+
+                // --- element 3 ---
+                i += 1;
+                if i > hi {
+                    break;
+                }
+                let v = self.zptr[i as usize];
+                let mut j = i;
+                loop {
+                    let zptr_jh = self.zptr[(j - h) as usize];
+                    if !self.full_gt_u(zptr_jh + d, v + d) {
+                        break;
+                    }
+                    self.zptr[j as usize] = zptr_jh;
+                    j -= h;
+                    if j <= lo + h - 1 {
+                        break;
+                    }
+                }
+                self.zptr[j as usize] = v;
+                i += 1;
+
+                // Early exit if too much work done (block will be randomised and retried).
+                if self.work_done > self.work_limit && self.first_attempt {
+                    return;
+                }
+            }
+            hp -= 1;
+        }
+    }
+
+    /// Compare two suffixes starting at positions `i1+1` and `i2+1`.
+    /// Returns `true` if suffix at `i1` is lexicographically greater than at `i2`.
+    ///
+    /// Two phases:
+    /// - Fast path: compare the first 6 bytes directly (no quadrant lookup).
+    /// - Slow path: compare 4 bytes per iteration, using `quadrant_shorts` to
+    ///   break ties. Each slow-path iteration increments `work_done` so the
+    ///   caller can detect worst-case inputs and bail out early.
+    fn full_gt_u(&mut self, mut i1: i32, mut i2: i32) -> bool {
+        // --- Fast path: first 6 bytes ---
+        // Unrolled to avoid loop overhead for the common case.
+        macro_rules! cmp_byte {
+            () => {
+                i1 += 1;
+                i2 += 1;
+                let c1 = self.block_bytes[i1 as usize];
+                let c2 = self.block_bytes[i2 as usize];
+                if c1 != c2 {
+                    return c1 > c2;
+                }
+            };
+        }
+        cmp_byte!();
+        cmp_byte!();
+        cmp_byte!();
+        cmp_byte!();
+        cmp_byte!();
+        cmp_byte!();
+
+        // --- Slow path: 4 bytes + quadrant tiebreak per iteration ---
+        // Processes the remaining suffix cyclically, wrapping around at `count`.
+        let mut k = self.count as i32;
+        loop {
+            macro_rules! cmp_byte_quad {
+                () => {
+                    i1 += 1;
+                    i2 += 1;
+                    let c1 = self.block_bytes[i1 as usize];
+                    let c2 = self.block_bytes[i2 as usize];
+                    if c1 != c2 {
+                        return c1 > c2;
+                    }
+                    let s1 = self.quadrant_shorts[i1 as usize];
+                    let s2 = self.quadrant_shorts[i2 as usize];
+                    if s1 != s2 {
+                        return s1 > s2;
+                    }
+                };
+            }
+            cmp_byte_quad!();
+            cmp_byte_quad!();
+            cmp_byte_quad!();
+            cmp_byte_quad!();
+
+            // Wrap around for cyclic suffix comparison.
+            let count = self.count as i32;
+            if i1 >= count {
+                i1 -= count;
+            }
+            if i2 >= count {
+                i2 -= count;
+            }
+
+            k -= 4;
+            self.work_done += 1;
+
+            if k < 0 {
+                break;
+            }
+        }
+
+        // All bytes equal — suffixes are identical rotations, treat as not greater.
+        false
+    }
+
+    /// Three-way quicksort on `zptr[lo..=hi]`, comparing suffixes at depth `d`.
+    ///
+    /// Uses an explicit stack (`blocksort_stack`) instead of recursion to avoid
+    /// system stack overflow on pathological inputs. Falls back to [`simple_sort`]
+    /// when the range is small or the depth exceeds [`DEPTH_THRESH`].
+    fn q_sort3(&mut self, lo_st: i32, hi_st: i32, d_st: i32) {
+        let mut lo = lo_st;
+        let mut hi = hi_st;
+        let mut d = d_st;
+
+        loop {
+            // Small range or deep recursion: delegate to Shell sort.
+            if hi - lo < SMALL_THRESH || d > DEPTH_THRESH {
+                self.simple_sort(lo, hi, d);
+                if self.block_sort_stack.is_empty()
+                    || (self.work_done > self.work_limit && self.first_attempt)
+                {
+                    return;
+                }
+                let (ll, hh, dd) = self.block_sort_stack.pop().unwrap();
+                lo = ll;
+                hi = hh;
+                d = dd;
+                continue;
+            }
+
+            let d1 = d + 1;
+
+            // Pivot: median of three at positions lo, hi, and mid.
+            let med = {
+                let a = self.block_bytes[self.zptr[lo as usize] as usize + d1 as usize] as i32;
+                let b = self.block_bytes[self.zptr[hi as usize] as usize + d1 as usize] as i32;
+                let c = self.block_bytes[self.zptr[((lo + hi) >> 1) as usize] as usize + d1 as usize] as i32;
+                Self::med3(a, b, c)
+            };
+
+            // Three-way partition (Dutch National Flag):
+            //   zptr[lo..ltLo]   < med
+            //   zptr[ltLo..unLo] = med
+            //   zptr[unHi+1..gtHi+1] = med
+            //   zptr[gtHi+1..=hi] > med
+            let (mut un_lo, mut lt_lo) = (lo, lo);
+            let (mut un_hi, mut gt_hi) = (hi, hi);
+
+            'partition: loop {
+                // Scan from left: skip elements equal to med (move to lt partition),
+                // stop when element > med.
+                while un_lo <= un_hi {
+                    let z_un_lo = self.zptr[un_lo as usize];
+                    let n = self.block_bytes[z_un_lo as usize + d1 as usize] as i32 - med;
+                    if n > 0 {
+                        break;
+                    }
+                    if n == 0 {
+                        self.zptr[un_lo as usize] = self.zptr[lt_lo as usize];
+                        self.zptr[lt_lo as usize] = z_un_lo;
+                        lt_lo += 1;
+                    }
+                    un_lo += 1;
+                }
+                // Scan from right: skip elements equal to med (move to gt partition),
+                // stop when element < med.
+                while un_lo <= un_hi {
+                    let z_un_hi = self.zptr[un_hi as usize];
+                    let n = self.block_bytes[z_un_hi as usize + d1 as usize] as i32 - med;
+                    if n < 0 {
+                        break;
+                    }
+                    if n == 0 {
+                        self.zptr[un_hi as usize] = self.zptr[gt_hi as usize];
+                        self.zptr[gt_hi as usize] = z_un_hi;
+                        gt_hi -= 1;
+                    }
+                    un_hi -= 1;
+                }
+                if un_lo > un_hi {
+                    break 'partition;
+                }
+                // Swap the out-of-place elements.
+                self.zptr.swap(un_lo as usize, un_hi as usize);
+                un_lo += 1;
+                un_hi -= 1;
+            }
+
+            // All elements equal to pivot: just go deeper.
+            if gt_hi < lt_lo {
+                d = d1;
+                continue;
+            }
+
+            // Move the equal-to-pivot elements from the edges to the centre.
+            let n = (lt_lo - lo).min(un_lo - lt_lo);
+            self.vswap(lo, un_lo - n, n);
+
+            let m = (hi - gt_hi).min(gt_hi - un_hi);
+            self.vswap(un_lo, hi - m + 1, m);
+
+            // Push the < and > sub-ranges onto the stack; handle = range next.
+            let n = lo + (un_lo - lt_lo);
+            let m = hi - (gt_hi - un_hi);
+
+            self.block_sort_stack.push((lo, n - 1, d));
+            self.block_sort_stack.push((n, m, d1));
+
+            lo = m + 1;
+        }
+    }
+
+    /// Swap `n` elements between `zptr[p1..]` and `zptr[p2..]`.
+    fn vswap(&mut self, mut p1: i32, mut p2: i32, mut n: i32) {
+        while n > 0 {
+            self.zptr.swap(p1 as usize, p2 as usize);
+            p1 += 1;
+            p2 += 1;
+            n -= 1;
+        }
+    }
+
+    /// Median of three values — used for pivot selection in [`q_sort3`].
+    fn med3(a: i32, b: i32, c: i32) -> i32 {
+        if a > b {
+            if c < b { b } else if c > a { a } else { c }
+        } else {
+            if c < a { a } else if c > b { b } else { c }
+        }
+    }
+
+    /// Lightly randomise the block to break up repetitive patterns that cause
+    /// worst-case sort behaviour. Called when the first [`main_sort`] attempt
+    /// exceeds `work_limit`. The same [`RNUMS`] table is used by the decompressor
+    /// to reverse the randomisation.
+    fn randomise_block(&mut self) {
+        // Reset in_use: randomisation may change which byte values are present.
+        self.in_use = [false; 256];
+
+        let mut r_n_to_go = 0i32;
+        let mut r_t_pos = 0usize;
+
+        for i in 1..=self.count {
+            if r_n_to_go == 0 {
+                r_n_to_go = RNUMS[r_t_pos] as i32;
+                r_t_pos = (r_t_pos + 1) & 0x1FF; // wrap at 512
+            }
+            r_n_to_go -= 1;
+
+            // XOR the byte with 1 exactly once per RNUMS cycle (when r_n_to_go == 1).
+            self.block_bytes[i] ^= if r_n_to_go == 1 { 1 } else { 0 };
+
+            self.in_use[self.block_bytes[i] as usize] = true;
+        }
+    }
+
+    /// Write a single bit. Specialised form of [`bs_put_bits_small`] for n = 1.
+    fn bs_put_bit(&mut self, v: i32) -> io::Result<()> {
+        self.bs_put_bits_small(1, v)
+    }
+
+    /// Write `n` bits (1–24) of `v` into the bit buffer, flushing whole bytes
+    /// to the inner writer as they fill up.
+    ///
+    /// The buffer (`bs_buff`) holds 32 bits. `bs_live_pos` counts down from 32
+    /// indicating how many free positions remain. When `bs_live_pos <= 24` there
+    /// are at least 8 ready bits; write the top byte and shift the buffer left.
+    fn bs_put_bits(&mut self, n: i32, v: i32) -> io::Result<()> {
+        debug_assert!((1..=24).contains(&n));
+        self.bs_live_pos -= n;
+        self.bs_buff |= v << self.bs_live_pos;
+        while self.bs_live_pos <= 24 {
+            self.inner.write_all(&[(self.bs_buff >> 24) as u8])?;
+            self.bs_buff <<= 8;
+            self.bs_live_pos += 8;
+        }
+        Ok(())
+    }
+
+    /// Write `n` bits (1–8) — single-flush variant of [`bs_put_bits`].
+    /// Because n ≤ 8, at most one byte needs to be flushed per call.
+    fn bs_put_bits_small(&mut self, n: i32, v: i32) -> io::Result<()> {
+        debug_assert!((1..=8).contains(&n));
+        self.bs_live_pos -= n;
+        self.bs_buff |= v << self.bs_live_pos;
+        if self.bs_live_pos <= 24 {
+            self.inner.write_all(&[(self.bs_buff >> 24) as u8])?;
+            self.bs_buff <<= 8;
+            self.bs_live_pos += 8;
+        }
+        Ok(())
+    }
+
+    /// Write a 32-bit value as two 16-bit halves.
+    fn bs_put_int32(&mut self, v: u32) -> io::Result<()> {
+        self.bs_put_bits(16, ((v >> 16) & 0xFFFF) as i32)?;
+        self.bs_put_bits(16, (v & 0xFFFF) as i32)
+    }
+
+    /// Write a 48-bit value as two 24-bit halves.
+    fn bs_put_long48(&mut self, v: u64) -> io::Result<()> {
+        self.bs_put_bits(24, ((v >> 24) & 0x00FF_FFFF) as i32)?;
+        self.bs_put_bits(24, (v & 0x00FF_FFFF) as i32)
+    }
+
+    fn move_to_front_code_and_send(&mut self) -> io::Result<()> {
+        // Write the BWT origin pointer so the decompressor knows which rotation
+        // is the original string.
+        self.bs_put_bits(24, self.orig_ptr as i32)?;
+        self.generate_mtf_values();
+        self.send_mtf_values()
+    }
+
+    /// Apply the Move-To-Front transform to the BWT output.
+    ///
+    /// Reads `block_bytes[zptr[i]]` for each sorted position, encodes it as
+    /// the symbol's current rank in the MTF alphabet `yy`, then moves it to
+    /// the front. Consecutive occurrences of rank 0 are batched into
+    /// `RUNA`/`RUNB` symbols using a bijective base-2 encoding.
+    /// Results are written into `zptr` (reused as `szptr`) and frequencies
+    /// into `mtf_freq`.
+    fn generate_mtf_values(&mut self) {
+        // Build the initial MTF alphabet from in-use byte values.
+        self.n_in_use = 0;
+        let mut yy = [0u8; 256];
+        for i in 0..256 {
+            if self.in_use[i] {
+                yy[self.n_in_use] = i as u8;
+                self.n_in_use += 1;
+            }
+        }
+
+        let eob = self.n_in_use + 1; // end-of-block symbol index
+
+        // Clear frequency table for all symbols including EOB.
+        for i in 0..=eob {
+            self.mtf_freq[i] = 0;
+        }
+
+        let mut wr = 0usize;  // write position in zptr (used as szptr)
+        let mut z_pend = 0usize; // pending count of rank-0 occurrences
+
+        for i in 0..self.count {
+            let block_byte = self.block_bytes[self.zptr[i] as usize];
+
+            // Fast path: byte matches the front of the alphabet (rank 0).
+            if block_byte == yy[0] {
+                z_pend += 1;
+                continue;
+            }
+
+            // Flush any pending run of rank-0 symbols as RUNA/RUNB sequence.
+            // Uses bijective base-2: repeatedly emit (z_pend-1) & 1 then shift.
+            while z_pend > 0 {
+                z_pend -= 1;
+                let run = z_pend & 1; // RUNA = 0, RUNB = 1
+                self.zptr[wr] = run as i32;
+                wr += 1;
+                self.mtf_freq[run] += 1;
+                z_pend >>= 1;
+            }
+
+            // Find the byte's position in yy and move it to the front.
+            let mut sym = 1usize;
+            let mut tmp = yy[0];
+            while block_byte != tmp {
+                let tmp2 = tmp;
+                tmp = yy[sym];
+                yy[sym] = tmp2;
+                sym += 1;
+            }
+            yy[0] = tmp;
+
+            // Emit the rank symbol.
+            self.zptr[wr] = sym as i32;
+            wr += 1;
+            self.mtf_freq[sym] += 1;
+        }
+
+        // Flush any remaining pending run.
+        while z_pend > 0 {
+            z_pend -= 1;
+            let run = z_pend & 1;
+            self.zptr[wr] = run as i32;
+            wr += 1;
+            self.mtf_freq[run] += 1;
+            z_pend >>= 1;
+        }
+
+        // Emit the end-of-block symbol.
+        self.zptr[wr] = eob as i32;
+        wr += 1;
+        self.mtf_freq[eob] += 1;
+
+        self.n_mtf = wr;
+    }
+
+    fn send_mtf_values(&mut self) -> io::Result<()> {
+        let alpha_size = self.n_in_use + 2;
+
+        if self.n_mtf == 0 {
+            return Err(io::Error::other("send_mtf_values: n_mtf is zero"));
+        }
+
+        // Choose number of Huffman tables based on MTF sequence length.
+        let n_groups = match self.n_mtf {
+            0..=199   => 2,
+            200..=599  => 3,
+            600..=1199 => 4,
+            1200..=2399 => 5,
+            _          => 6,
+        };
+
+        // Initialise code-length tables with GREATER_ICOST (15 = "don't use").
+        let mut len = [[GREATER_ICOST; MAX_ALPHA_SIZE]; N_GROUPS];
+
+        // Initial table assignment: divide the MTF sequence into nGroups
+        // equal-frequency partitions and mark each partition's symbols as preferred.
+        {
+            let mut n_part = n_groups as i32;
+            let mut rem_f  = self.n_mtf as i32;
+            let mut ge     = -1i32;
+
+            while n_part > 0 {
+                let gs     = ge + 1;
+                let mut a_freq = 0i32;
+                let t_freq = rem_f / n_part;
+
+                while a_freq < t_freq && ge < alpha_size as i32 - 1 {
+                    ge += 1;
+                    a_freq += self.mtf_freq[ge as usize];
+                }
+
+                // Bias correction for odd-numbered partitions.
+                if ge > gs
+                    && n_part != n_groups as i32
+                    && n_part != 1
+                    && (n_groups as i32 - n_part) % 2 == 1
+                {
+                    a_freq -= self.mtf_freq[ge as usize];
+                    ge -= 1;
+                }
+
+                let len_np = &mut len[(n_part - 1) as usize];
+                for v in 0..alpha_size {
+                    len_np[v] = if v >= gs as usize && v <= ge as usize {
+                        LESSER_ICOST
+                    } else {
+                        GREATER_ICOST
+                    };
+                }
+
+                n_part -= 1;
+                rem_f  -= a_freq;
+            }
+        }
+
+        // Iterative optimisation: N_ITERS rounds of (selector assignment →
+        // frequency accumulation → code-length recomputation).
+        let mut rfreq = [[0i32; MAX_ALPHA_SIZE]; N_GROUPS];
+        let mut fave: [i32; N_GROUPS]; // initialised at the top of every iteration
+        let mut cost  = [0i16; N_GROUPS];
+        let mut n_selectors = 0usize;
+
+        for _iter in 0..N_ITERS {
+            fave = [0i32; N_GROUPS];
+            for t in 0..n_groups {
+                rfreq[t][..alpha_size].fill(0);
+            }
+
+            n_selectors = 0;
+            let mut gs = 0usize;
+
+            while gs < self.n_mtf {
+                let ge = (gs + G_SIZE - 1).min(self.n_mtf - 1);
+
+                // Cost of encoding this G_SIZE group with each table.
+                if n_groups == 6 {
+                    let (mut c0, mut c1, mut c2, mut c3, mut c4, mut c5) =
+                        (0i16, 0i16, 0i16, 0i16, 0i16, 0i16);
+                    for i in gs..=ge {
+                        let icv = self.zptr[i] as usize;
+                        c0 += len[0][icv] as i16;
+                        c1 += len[1][icv] as i16;
+                        c2 += len[2][icv] as i16;
+                        c3 += len[3][icv] as i16;
+                        c4 += len[4][icv] as i16;
+                        c5 += len[5][icv] as i16;
+                    }
+                    cost[0] = c0; cost[1] = c1; cost[2] = c2;
+                    cost[3] = c3; cost[4] = c4; cost[5] = c5;
+                } else {
+                    for t in 0..n_groups { cost[t] = 0; }
+                    for i in gs..=ge {
+                        let icv = self.zptr[i] as usize;
+                        for t in 0..n_groups {
+                            cost[t] += len[t][icv] as i16;
+                        }
+                    }
+                }
+
+                // Select cheapest table.
+                let mut bc = cost[0] as i32;
+                let mut bt = 0usize;
+                for t in 1..n_groups {
+                    let ct = cost[t] as i32;
+                    if ct < bc { bc = ct; bt = t; }
+                }
+                fave[bt] += 1;
+                self.selectors[n_selectors] = bt as u8;
+                n_selectors += 1;
+
+                for i in gs..=ge {
+                    rfreq[bt][self.zptr[i] as usize] += 1;
+                }
+
+                gs = ge + 1;
+            }
+
+            // Rebuild code lengths from accumulated frequencies.
+            for t in 0..n_groups {
+                Self::hb_make_code_lengths(
+                    &mut len[t], &rfreq[t], alpha_size, MAX_CODE_LEN_GEN,
+                );
+            }
+        }
+
+        debug_assert!(n_groups <= N_GROUPS);
+        debug_assert!(n_selectors <= MAX_SELECTORS);
+
+        // Assign canonical Huffman codes from the final code lengths.
+        let mut code = [[0i32; MAX_ALPHA_SIZE]; N_GROUPS];
+        for t in 0..n_groups {
+            let mut max_len = 0i32;
+            let mut min_len = 32i32;
+            for i in 0..alpha_size {
+                let lti = len[t][i] as i32;
+                max_len = max_len.max(lti);
+                min_len = min_len.min(lti);
+            }
+            debug_assert!(min_len >= 1 && max_len <= MAX_CODE_LEN_GEN as i32);
+            Self::hb_assign_codes(&mut code[t], &len[t], min_len, max_len, alpha_size);
+        }
+
+        // --- Output ---
+
+        // Mapping table: which byte values appear in this block (16×16 bitmap).
+        let mut in_use16 = [false; 16];
+        for i in 0..16usize {
+            for j in 0..16usize {
+                if self.in_use[i * 16 + j] {
+                    in_use16[i] = true;
+                    break;
+                }
+            }
+        }
+        for i in 0..16 {
+            self.bs_put_bit(in_use16[i] as i32)?;
+        }
+        for i in 0..16usize {
+            if in_use16[i] {
+                for j in 0..16usize {
+                    self.bs_put_bit(self.in_use[i * 16 + j] as i32)?;
+                }
+            }
+        }
+
+        // Selectors: 3-bit group count, 15-bit selector count, then each
+        // selector encoded as its MTF rank in unary (rank-1 ones then a 0).
+        // MTF ranks are 1-indexed (initial state 0x00654321 stores ranks 1–6).
+        self.bs_put_bits_small(3, n_groups as i32)?;
+        self.bs_put_bits(15, n_selectors as i32)?;
+        {
+            let mut mtf_selectors = 0x00654321i32;
+            for i in 0..n_selectors {
+                let ll_i    = self.selectors[i] as i32;
+                let bit_pos = ll_i << 2;
+                let mtf_sel = (mtf_selectors >> bit_pos) & 0xF;
+
+                // Move to front if not already there (rank 1 = already at front).
+                if mtf_sel != 1 {
+                    let inc_mask = (0x00888888i32
+                        .wrapping_sub(mtf_selectors)
+                        .wrapping_add(0x00111111i32.wrapping_mul(mtf_sel)))
+                        & 0x00888888i32;
+                    mtf_selectors = mtf_selectors
+                        .wrapping_sub(mtf_sel << bit_pos)
+                        .wrapping_add(inc_mask >> 3);
+                }
+
+                // Write (rank-1) ones followed by one 0:
+                // (1 << rank) - 2  in  rank  bits produces 0b111...10.
+                self.bs_put_bits_small(mtf_sel, (1 << mtf_sel) - 2)?;
+            }
+        }
+
+        // Coding tables: delta-encoded lengths.
+        // Symbol 0: 5-bit length packed with a 0-bit terminator into 6 bits.
+        // Symbols 1+: pairs of "10" (increment) or "11" (decrement) then "0" (stop).
+        for t in 0..n_groups {
+            let mut curr = len[t][0] as i32;
+            self.bs_put_bits_small(6, curr << 1)?;
+            for i in 1..alpha_size {
+                let lti = len[t][i] as i32;
+                while curr < lti { self.bs_put_bits_small(2, 2)?; curr += 1; } // 10
+                while curr > lti { self.bs_put_bits_small(2, 3)?; curr -= 1; } // 11
+                self.bs_put_bit(0)?; // stop
+            }
+        }
+
+        // Block data: Huffman-encode each MTF symbol using the selected table.
+        let mut sel_ctr = 0usize;
+        let mut gs = 0usize;
+        while gs < self.n_mtf {
+            let ge  = (gs + G_SIZE - 1).min(self.n_mtf - 1);
+            let sel = self.selectors[sel_ctr] as usize;
+            for i in gs..=ge {
+                let sym = self.zptr[i] as usize;
+                self.bs_put_bits(len[sel][sym] as i32, code[sel][sym])?;
+            }
+            gs = ge + 1;
+            sel_ctr += 1;
+        }
+        debug_assert!(sel_ctr == n_selectors);
+
+        Ok(())
+    }
+
+    /// Build Huffman code lengths from symbol frequencies using a min-heap.
+    /// If any length exceeds `max_len`, halve all weights and retry.
+    fn hb_make_code_lengths(
+        len: &mut [u8],
+        freq: &[i32],
+        alpha_size: usize,
+        max_len: usize,
+    ) {
+        // Heap, weight, and parent arrays are 1-indexed; index 0 is a sentinel.
+        let mut heap   = [0i32; MAX_ALPHA_SIZE + 2];
+        let mut weight = [0i32; MAX_ALPHA_SIZE * 2];
+        let mut parent = [0i32; MAX_ALPHA_SIZE * 2];
+
+        // Leaf weights: high 24 bits hold frequency, low 8 bits hold depth (0).
+        for i in 0..alpha_size {
+            weight[i + 1] = (if freq[i] == 0 { 1 } else { freq[i] }) << 8;
+        }
+
+        loop {
+            let mut n_nodes = alpha_size;
+            let mut n_heap  = 0usize;
+
+            heap[0]   = 0;
+            weight[0] = 0;
+            parent[0] = -2;
+
+            // Insert all leaf nodes into the min-heap.
+            for i in 1..=alpha_size {
+                parent[i] = -1;
+                n_heap += 1;
+                heap[n_heap] = i as i32;
+                // Sift up.
+                let mut zz = n_heap;
+                let tmp = heap[zz];
+                while weight[tmp as usize] < weight[heap[zz >> 1] as usize] {
+                    heap[zz] = heap[zz >> 1];
+                    zz >>= 1;
+                }
+                heap[zz] = tmp;
+            }
+            debug_assert!(n_heap < MAX_ALPHA_SIZE + 2);
+
+            // Build Huffman tree by repeatedly merging the two lightest nodes.
+            while n_heap > 1 {
+                // Extract minimum → n1.
+                let n1 = heap[1];
+                heap[1] = heap[n_heap];
+                n_heap -= 1;
+                Self::sift_down(&mut heap, &weight, n_heap, 1);
+
+                // Extract minimum → n2.
+                let n2 = heap[1];
+                heap[1] = heap[n_heap];
+                n_heap -= 1;
+                Self::sift_down(&mut heap, &weight, n_heap, 1);
+
+                // Create internal node combining n1 and n2.
+                n_nodes += 1;
+                parent[n1 as usize] = n_nodes as i32;
+                parent[n2 as usize] = n_nodes as i32;
+
+                let w1 = weight[n1 as usize];
+                let w2 = weight[n2 as usize];
+                weight[n_nodes] = (((w1 as u32 & 0xFFFFFF00)
+                    + (w2 as u32 & 0xFFFFFF00))
+                    | (1 + (w1 & 0xFF).max(w2 & 0xFF) as u32))
+                    as i32;
+
+                parent[n_nodes] = -1;
+                n_heap += 1;
+                heap[n_heap] = n_nodes as i32;
+                // Sift up.
+                let mut zz = n_heap;
+                let tmp = heap[zz];
+                while weight[tmp as usize] < weight[heap[zz >> 1] as usize] {
+                    heap[zz] = heap[zz >> 1];
+                    zz >>= 1;
+                }
+                heap[zz] = tmp;
+            }
+            debug_assert!(n_nodes < MAX_ALPHA_SIZE * 2);
+
+            // Compute code lengths as tree depths.
+            let mut too_long_bits = 0i32;
+            for i in 1..=alpha_size {
+                let mut depth = 0i32;
+                let mut k = i;
+                while parent[k] >= 0 {
+                    k = parent[k] as usize;
+                    depth += 1;
+                }
+                len[i - 1] = depth as u8;
+                too_long_bits |= max_len as i32 - depth;
+            }
+
+            if too_long_bits >= 0 {
+                break; // All lengths within max_len.
+            }
+
+            // Some depths exceeded max_len: halve all leaf weights and retry.
+            for i in 1..=alpha_size {
+                let j = weight[i] >> 8;
+                weight[i] = (1 + j / 2) << 8;
+            }
+        }
+    }
+
+    /// Sift the element at `pos` down in the min-heap to restore heap order.
+    fn sift_down(heap: &mut [i32], weight: &[i32], n_heap: usize, pos: usize) {
+        let mut zz = pos;
+        let tmp = heap[zz];
+        loop {
+            let mut yy = zz << 1;
+            if yy > n_heap { break; }
+            if yy < n_heap && weight[heap[yy + 1] as usize] < weight[heap[yy] as usize] {
+                yy += 1;
+            }
+            if weight[tmp as usize] < weight[heap[yy] as usize] { break; }
+            heap[zz] = heap[yy];
+            zz = yy;
+        }
+        heap[zz] = tmp;
+    }
+
+    /// Assign canonical Huffman codes from code lengths.
+    fn hb_assign_codes(
+        code: &mut [i32],
+        length: &[u8],
+        min_len: i32,
+        max_len: i32,
+        alpha_size: usize,
+    ) {
+        let mut vec = 0i32;
+        for n in min_len..=max_len {
+            for i in 0..alpha_size {
+                if length[i] as i32 == n {
+                    code[i] = vec;
+                    vec += 1;
+                }
+            }
+            vec <<= 1;
+        }
+    }
+
+    /// Flush any bits still sitting in `bs_buff` to the inner writer.
+    ///
+    /// After all blocks have been written the bit buffer may hold up to 7
+    /// partial bits. They are padded with trailing zero bits to complete the
+    /// last byte before writing.
+    fn bs_finished_with_stream(&mut self) -> io::Result<()> {
+        // bs_live_pos counts *free* positions in the 32-bit buffer, starting
+        // at 32. Any value < 32 means at least one bit is waiting.
+        while self.bs_live_pos < 32 {
+            self.inner.write_all(&[(self.bs_buff >> 24) as u8])?;
+            self.bs_buff <<= 8;
+            self.bs_live_pos += 8;
+        }
+        Ok(())
+    }
+
+    /// Write the bzip2 end-of-stream marker and flush the bit buffer.
+    ///
+    /// Outputs:
+    /// 1. The 48-bit EOS magic `0x177245385090` (a truncated hex encoding of
+    ///    √π, chosen by the bzip2 spec to be distinct from the per-block magic).
+    /// 2. The 32-bit combined stream CRC accumulated across all blocks.
+    /// 3. Any partial bits left in the bit buffer, zero-padded to a full byte.
+    fn end_compression(&mut self) -> io::Result<()> {
+        self.bs_put_long48(0x177245385090)?;
+        self.bs_put_int32(self.stream_crc)?;
+        self.bs_finished_with_stream()
+    }
+}
+
+impl<W: Write> Write for BZip2Writer<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        for &byte in buf {
+            self.write_byte_internal(byte)?;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl<W: Write> Drop for BZip2Writer<W> {
+    fn drop(&mut self) {
+        if !self.finished {
+            let _ = self.finish();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Compress `data` with the given block size; returns the bzip2 bytes.
+    ///
+    /// `w` is scoped to a block so its borrow of `buf` is released before
+    /// we return the vector.
+    fn compress(data: &[u8], block_size: usize) -> Vec<u8> {
+        let mut buf = Vec::new();
+        {
+            let mut w = BZip2Writer::with_block_size(&mut buf, block_size).unwrap();
+            w.write_all(data).unwrap();
+            w.finish().unwrap();
+        }
+        buf
+    }
+
+    /// An empty bzip2 stream (block size 9) has a fixed 14-byte layout:
+    ///   "BZh9"  (4 bytes)  stream header
+    ///   EOS magic 0x177245385090  (6 bytes, big-endian 48-bit)
+    ///   stream CRC 0x00000000  (4 bytes)
+    /// No padding bytes because every field aligns to an octet boundary.
+    #[test]
+    fn empty_stream_exact_bytes() {
+        let out = compress(b"", 9);
+        assert_eq!(out, &[
+            b'B', b'Z', b'h', b'9',             // "BZh9"
+            0x17, 0x72, 0x45, 0x38, 0x50, 0x90, // EOS magic √π
+            0x00, 0x00, 0x00, 0x00,              // stream CRC (no blocks)
+        ]);
+    }
+
+    /// Block size digit in the header must reflect the requested level (1–9).
+    #[test]
+    fn header_block_size_digit() {
+        for size in 1usize..=9 {
+            let out = compress(b"", size);
+            assert_eq!(&out[..4], &[b'B', b'Z', b'h', b'0' + size as u8],
+                "wrong header for block_size={size}");
+        }
+    }
+
+    /// Block size is clamped: values outside 1–9 are accepted without panic.
+    #[test]
+    fn block_size_clamped() {
+        let lo = compress(b"", 0);   // clamped to 1 → 'BZh1'
+        let hi = compress(b"", 99);  // clamped to 9 → 'BZh9'
+        assert_eq!(lo[3], b'1');
+        assert_eq!(hi[3], b'9');
+    }
+
+    /// Writing data must not panic; output must start with the correct header.
+    #[test]
+    fn nonempty_stream_starts_with_header() {
+        for data in [
+            b"a".as_slice(),
+            b"hello, world!",
+            &[0u8; 1000],       // long run
+            &[0u8; 100_001],    // forces a block flush
+        ] {
+            let out = compress(data, 9);
+            assert_eq!(&out[..3], b"BZh", "header mismatch for input len={}", data.len());
+        }
+    }
+
+    /// Calling finish() twice must produce the same output as calling it once
+    /// (second call is a no-op).
+    #[test]
+    fn finish_idempotent() {
+        // single finish via explicit call + Drop
+        let mut once = Vec::new();
+        {
+            let mut w = BZip2Writer::new(&mut once).unwrap();
+            w.finish().unwrap();
+        }
+
+        // two explicit finish() calls before Drop
+        let mut twice = Vec::new();
+        {
+            let mut w = BZip2Writer::new(&mut twice).unwrap();
+            w.finish().unwrap();
+            w.finish().unwrap();
+        }
+
+        assert_eq!(once, twice);
+    }
+}

--- a/src/util/bzip2/bzip2_writer.rs
+++ b/src/util/bzip2/bzip2_writer.rs
@@ -405,8 +405,8 @@ impl<W: Write> BZip2Writer<W> {
 
         // Sort big buckets by size (smallest first) using Shell sort.
         let mut running_order = [0i32; 256];
-        for i in 0..256 {
-            running_order[i] = i as i32;
+        for (i, r) in running_order.iter_mut().enumerate() {
+            *r = i as i32;
         }
         let mut h = 1i32;
         while h <= 256 {
@@ -444,8 +444,8 @@ impl<W: Write> BZip2Writer<W> {
         let mut copy = [0i32; 256];
         let mut big_done = [false; 256];
 
-        for i in 0..256usize {
-            let ss = running_order[i] as usize;
+        for (i, &ss_i) in running_order.iter().enumerate() {
+            let ss = ss_i as usize;
 
             // QSort3 any unsorted small buckets [ss, j].
             for j in 0..256usize {
@@ -486,8 +486,8 @@ impl<W: Write> BZip2Writer<W> {
             }
 
             // Synthesise sorted order for small buckets [t, ss] for all t != ss.
-            for j in 0..256usize {
-                copy[j] = self.ftab[(j << 8) + ss] & CLEAR_MASK;
+            for (j, c) in copy.iter_mut().enumerate() {
+                *c = self.ftab[(j << 8) + ss] & CLEAR_MASK;
             }
             for j in (self.ftab[ss << 8] & CLEAR_MASK) as usize
                 ..(self.ftab[(ss + 1) << 8] & CLEAR_MASK) as usize
@@ -545,7 +545,7 @@ impl<W: Write> BZip2Writer<W> {
                     }
                     self.zptr[j as usize] = zptr_jh;
                     j -= h;
-                    if j <= lo + h - 1 {
+                    if j < lo + h {
                         break;
                     }
                 }
@@ -565,7 +565,7 @@ impl<W: Write> BZip2Writer<W> {
                     }
                     self.zptr[j as usize] = zptr_jh;
                     j -= h;
-                    if j <= lo + h - 1 {
+                    if j < lo + h {
                         break;
                     }
                 }
@@ -585,7 +585,7 @@ impl<W: Write> BZip2Writer<W> {
                     }
                     self.zptr[j as usize] = zptr_jh;
                     j -= h;
-                    if j <= lo + h - 1 {
+                    if j < lo + h {
                         break;
                     }
                 }
@@ -938,9 +938,7 @@ impl<W: Write> BZip2Writer<W> {
             let mut sym = 1usize;
             let mut tmp = yy[0];
             while block_byte != tmp {
-                let tmp2 = tmp;
-                tmp = yy[sym];
-                yy[sym] = tmp2;
+                std::mem::swap(&mut tmp, &mut yy[sym]);
                 sym += 1;
             }
             yy[0] = tmp;
@@ -1016,8 +1014,8 @@ impl<W: Write> BZip2Writer<W> {
                 }
 
                 let len_np = &mut len[(n_part - 1) as usize];
-                for v in 0..alpha_size {
-                    len_np[v] = if v >= gs as usize && v <= ge as usize {
+                for (v, l) in len_np.iter_mut().enumerate().take(alpha_size) {
+                    *l = if v >= gs as usize && v <= ge as usize {
                         LESSER_ICOST
                     } else {
                         GREATER_ICOST
@@ -1038,8 +1036,8 @@ impl<W: Write> BZip2Writer<W> {
 
         for _iter in 0..N_ITERS {
             fave = [0i32; N_GROUPS];
-            for t in 0..n_groups {
-                rfreq[t][..alpha_size].fill(0);
+            for rfreq_t in rfreq.iter_mut().take(n_groups) {
+                rfreq_t[..alpha_size].fill(0);
             }
 
             n_selectors = 0;
@@ -1064,7 +1062,7 @@ impl<W: Write> BZip2Writer<W> {
                     cost[0] = c0; cost[1] = c1; cost[2] = c2;
                     cost[3] = c3; cost[4] = c4; cost[5] = c5;
                 } else {
-                    for t in 0..n_groups { cost[t] = 0; }
+                    cost[..n_groups].fill(0);
                     for i in gs..=ge {
                         let icv = self.zptr[i] as usize;
                         for t in 0..n_groups {
@@ -1076,8 +1074,8 @@ impl<W: Write> BZip2Writer<W> {
                 // Select cheapest table.
                 let mut bc = cost[0] as i32;
                 let mut bt = 0usize;
-                for t in 1..n_groups {
-                    let ct = cost[t] as i32;
+                for (t, &c) in cost.iter().enumerate().take(n_groups).skip(1) {
+                    let ct = c as i32;
                     if ct < bc { bc = ct; bt = t; }
                 }
                 fave[bt] += 1;
@@ -1107,8 +1105,8 @@ impl<W: Write> BZip2Writer<W> {
         for t in 0..n_groups {
             let mut max_len = 0i32;
             let mut min_len = 32i32;
-            for i in 0..alpha_size {
-                let lti = len[t][i] as i32;
+            for &l in len[t].iter().take(alpha_size) {
+                let lti = l as i32;
                 max_len = max_len.max(lti);
                 min_len = min_len.min(lti);
             }
@@ -1120,19 +1118,19 @@ impl<W: Write> BZip2Writer<W> {
 
         // Mapping table: which byte values appear in this block (16×16 bitmap).
         let mut in_use16 = [false; 16];
-        for i in 0..16usize {
+        for (i, flag) in in_use16.iter_mut().enumerate() {
             for j in 0..16usize {
                 if self.in_use[i * 16 + j] {
-                    in_use16[i] = true;
+                    *flag = true;
                     break;
                 }
             }
         }
-        for i in 0..16 {
-            self.bs_put_bit(in_use16[i] as i32)?;
+        for &flag in &in_use16 {
+            self.bs_put_bit(flag as i32)?;
         }
-        for i in 0..16usize {
-            if in_use16[i] {
+        for (i, &flag) in in_use16.iter().enumerate() {
+            if flag {
                 for j in 0..16usize {
                     self.bs_put_bit(self.in_use[i * 16 + j] as i32)?;
                 }
@@ -1171,11 +1169,11 @@ impl<W: Write> BZip2Writer<W> {
         // Coding tables: delta-encoded lengths.
         // Symbol 0: 5-bit length packed with a 0-bit terminator into 6 bits.
         // Symbols 1+: pairs of "10" (increment) or "11" (decrement) then "0" (stop).
-        for t in 0..n_groups {
-            let mut curr = len[t][0] as i32;
+        for len_t in len.iter().take(n_groups) {
+            let mut curr = len_t[0] as i32;
             self.bs_put_bits_small(6, curr << 1)?;
-            for i in 1..alpha_size {
-                let lti = len[t][i] as i32;
+            for &l in len_t[1..alpha_size].iter() {
+                let lti = l as i32;
                 while curr < lti { self.bs_put_bits_small(2, 2)?; curr += 1; } // 10
                 while curr > lti { self.bs_put_bits_small(2, 3)?; curr -= 1; } // 11
                 self.bs_put_bit(0)?; // stop
@@ -1227,8 +1225,8 @@ impl<W: Write> BZip2Writer<W> {
             parent[0] = -2;
 
             // Insert all leaf nodes into the min-heap.
-            for i in 1..=alpha_size {
-                parent[i] = -1;
+            for (i, p) in parent.iter_mut().enumerate().skip(1).take(alpha_size) {
+                *p = -1;
                 n_heap += 1;
                 heap[n_heap] = i as i32;
                 // Sift up.
@@ -1300,9 +1298,9 @@ impl<W: Write> BZip2Writer<W> {
             }
 
             // Some depths exceeded max_len: halve all leaf weights and retry.
-            for i in 1..=alpha_size {
-                let j = weight[i] >> 8;
-                weight[i] = (1 + j / 2) << 8;
+            for w in weight[1..=alpha_size].iter_mut() {
+                let j = *w >> 8;
+                *w = (1 + j / 2) << 8;
             }
         }
     }

--- a/src/util/bzip2/constants.rs
+++ b/src/util/bzip2/constants.rs
@@ -30,7 +30,6 @@ pub(super) const BASE_BLOCK_SIZE: usize = 100_000;
 pub(super) const MAX_ALPHA_SIZE: usize = 258;
 
 /// Maximum Huffman code length allowed during **decoding**.
-#[allow(dead_code)] // used by bzip2_reader (not yet implemented)
 pub(super) const MAX_CODE_LEN: usize = 20;
 
 /// Maximum Huffman code length allowed during **encoding** (code generation).
@@ -40,11 +39,9 @@ pub(super) const MAX_CODE_LEN_GEN: usize = 17;
 
 /// Run-length symbol A. Together with [`RUNB`], encodes the length of a
 /// run of repeated bytes using a binary (Fibonacci-like) encoding.
-#[allow(dead_code)] // used by bzip2_reader (not yet implemented)
 pub(super) const RUNA: usize = 0;
 
 /// Run-length symbol B. See [`RUNA`].
-#[allow(dead_code)] // used by bzip2_reader (not yet implemented)
 pub(super) const RUNB: usize = 1;
 
 /// Maximum number of Huffman tables used per block.

--- a/src/util/bzip2/constants.rs
+++ b/src/util/bzip2/constants.rs
@@ -1,0 +1,69 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package is based on the work done by Keiron Liddle, Aftex Software
+// <keiron@aftexsw.com> to whom the Ant project is very grateful for his
+// great code.
+
+//! BZip2 shared constants.
+//!
+//! Port of `BZip2Constants.cs` from bc-csharp.
+
+/// Base block size in bytes. Actual block size = `BASE_BLOCK_SIZE * level` (level 1–9),
+/// giving a maximum of 900,000 bytes at level 9.
+pub(super) const BASE_BLOCK_SIZE: usize = 100_000;
+
+/// Maximum Huffman alphabet size: 256 possible byte values plus the two
+/// run-length symbols [`RUNA`] and [`RUNB`].
+pub(super) const MAX_ALPHA_SIZE: usize = 258;
+
+/// Maximum Huffman code length allowed during **decoding**.
+#[allow(dead_code)] // used by bzip2_reader (not yet implemented)
+pub(super) const MAX_CODE_LEN: usize = 20;
+
+/// Maximum Huffman code length allowed during **encoding** (code generation).
+/// Kept smaller than [`MAX_CODE_LEN`] so every generated code is guaranteed
+/// to be decodable.
+pub(super) const MAX_CODE_LEN_GEN: usize = 17;
+
+/// Run-length symbol A. Together with [`RUNB`], encodes the length of a
+/// run of repeated bytes using a binary (Fibonacci-like) encoding.
+#[allow(dead_code)] // used by bzip2_reader (not yet implemented)
+pub(super) const RUNA: usize = 0;
+
+/// Run-length symbol B. See [`RUNA`].
+#[allow(dead_code)] // used by bzip2_reader (not yet implemented)
+pub(super) const RUNB: usize = 1;
+
+/// Maximum number of Huffman tables used per block.
+/// Each segment of [`G_SIZE`] symbols selects one of these tables via a selector.
+pub(super) const N_GROUPS: usize = 6;
+
+/// Number of symbols per Huffman group (segment).
+/// Every [`G_SIZE`] symbols the active Huffman table may change.
+pub(super) const G_SIZE: usize = 50;
+
+/// Number of iterations used to optimise Huffman tables during compression.
+/// Frequencies are collected and tables are rebuilt [`N_ITERS`] times to
+/// converge toward an optimal assignment.
+pub(super) const N_ITERS: usize = 4;
+
+/// Maximum number of selectors in a block.
+/// `= 2 + (max_block_size / G_SIZE)` where max block size is 900,000 bytes.
+pub(super) const MAX_SELECTORS: usize = 2 + (900_000 / G_SIZE);
+
+/// Number of extra bytes appended beyond the block during BWT sorting to
+/// prevent out-of-bounds reads during suffix comparisons.
+pub(super) const NUM_OVERSHOOT_BYTES: usize = 20;

--- a/src/util/bzip2/crc.rs
+++ b/src/util/bzip2/crc.rs
@@ -1,0 +1,224 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package is based on the work done by Keiron Liddle, Aftex Software
+// <keiron@aftexsw.com> to whom the Ant project is very grateful for his
+// great code.
+
+//! BZip2-specific CRC-32 implementation.
+//!
+//! Port of `CRC.cs` from bc-csharp.
+//!
+//! This is **not** the standard CRC-32 (IEEE 802.3 / ZIP / PNG).
+//! It uses the non-reflected polynomial 0x04C11DB7 with byte-reversed
+//! table entries and a byte-swap in [`Crc::get_final`], matching the
+//! bzip2 format specification.
+
+/// Byte-reversed CRC-32 lookup table (polynomial 0x04C11DB7, MSB-first).
+const CRC32_TABLE: [u32; 256] = [
+    0x00000000, 0xB71DC104, 0x6E3B8209, 0xD926430D,
+    0xDC760413, 0x6B6BC517, 0xB24D861A, 0x0550471E,
+    0xB8ED0826, 0x0FF0C922, 0xD6D68A2F, 0x61CB4B2B,
+    0x649B0C35, 0xD386CD31, 0x0AA08E3C, 0xBDBD4F38,
+    0x70DB114C, 0xC7C6D048, 0x1EE09345, 0xA9FD5241,
+    0xACAD155F, 0x1BB0D45B, 0xC2969756, 0x758B5652,
+    0xC836196A, 0x7F2BD86E, 0xA60D9B63, 0x11105A67,
+    0x14401D79, 0xA35DDC7D, 0x7A7B9F70, 0xCD665E74,
+    0xE0B62398, 0x57ABE29C, 0x8E8DA191, 0x39906095,
+    0x3CC0278B, 0x8BDDE68F, 0x52FBA582, 0xE5E66486,
+    0x585B2BBE, 0xEF46EABA, 0x3660A9B7, 0x817D68B3,
+    0x842D2FAD, 0x3330EEA9, 0xEA16ADA4, 0x5D0B6CA0,
+    0x906D32D4, 0x2770F3D0, 0xFE56B0DD, 0x494B71D9,
+    0x4C1B36C7, 0xFB06F7C3, 0x2220B4CE, 0x953D75CA,
+    0x28803AF2, 0x9F9DFBF6, 0x46BBB8FB, 0xF1A679FF,
+    0xF4F63EE1, 0x43EBFFE5, 0x9ACDBCE8, 0x2DD07DEC,
+    0x77708634, 0xC06D4730, 0x194B043D, 0xAE56C539,
+    0xAB068227, 0x1C1B4323, 0xC53D002E, 0x7220C12A,
+    0xCF9D8E12, 0x78804F16, 0xA1A60C1B, 0x16BBCD1F,
+    0x13EB8A01, 0xA4F64B05, 0x7DD00808, 0xCACDC90C,
+    0x07AB9778, 0xB0B6567C, 0x69901571, 0xDE8DD475,
+    0xDBDD936B, 0x6CC0526F, 0xB5E61162, 0x02FBD066,
+    0xBF469F5E, 0x085B5E5A, 0xD17D1D57, 0x6660DC53,
+    0x63309B4D, 0xD42D5A49, 0x0D0B1944, 0xBA16D840,
+    0x97C6A5AC, 0x20DB64A8, 0xF9FD27A5, 0x4EE0E6A1,
+    0x4BB0A1BF, 0xFCAD60BB, 0x258B23B6, 0x9296E2B2,
+    0x2F2BAD8A, 0x98366C8E, 0x41102F83, 0xF60DEE87,
+    0xF35DA999, 0x4440689D, 0x9D662B90, 0x2A7BEA94,
+    0xE71DB4E0, 0x500075E4, 0x892636E9, 0x3E3BF7ED,
+    0x3B6BB0F3, 0x8C7671F7, 0x555032FA, 0xE24DF3FE,
+    0x5FF0BCC6, 0xE8ED7DC2, 0x31CB3ECF, 0x86D6FFCB,
+    0x8386B8D5, 0x349B79D1, 0xEDBD3ADC, 0x5AA0FBD8,
+    0xEEE00C69, 0x59FDCD6D, 0x80DB8E60, 0x37C64F64,
+    0x3296087A, 0x858BC97E, 0x5CAD8A73, 0xEBB04B77,
+    0x560D044F, 0xE110C54B, 0x38368646, 0x8F2B4742,
+    0x8A7B005C, 0x3D66C158, 0xE4408255, 0x535D4351,
+    0x9E3B1D25, 0x2926DC21, 0xF0009F2C, 0x471D5E28,
+    0x424D1936, 0xF550D832, 0x2C769B3F, 0x9B6B5A3B,
+    0x26D61503, 0x91CBD407, 0x48ED970A, 0xFFF0560E,
+    0xFAA01110, 0x4DBDD014, 0x949B9319, 0x2386521D,
+    0x0E562FF1, 0xB94BEEF5, 0x606DADF8, 0xD7706CFC,
+    0xD2202BE2, 0x653DEAE6, 0xBC1BA9EB, 0x0B0668EF,
+    0xB6BB27D7, 0x01A6E6D3, 0xD880A5DE, 0x6F9D64DA,
+    0x6ACD23C4, 0xDDD0E2C0, 0x04F6A1CD, 0xB3EB60C9,
+    0x7E8D3EBD, 0xC990FFB9, 0x10B6BCB4, 0xA7AB7DB0,
+    0xA2FB3AAE, 0x15E6FBAA, 0xCCC0B8A7, 0x7BDD79A3,
+    0xC660369B, 0x717DF79F, 0xA85BB492, 0x1F467596,
+    0x1A163288, 0xAD0BF38C, 0x742DB081, 0xC3307185,
+    0x99908A5D, 0x2E8D4B59, 0xF7AB0854, 0x40B6C950,
+    0x45E68E4E, 0xF2FB4F4A, 0x2BDD0C47, 0x9CC0CD43,
+    0x217D827B, 0x9660437F, 0x4F460072, 0xF85BC176,
+    0xFD0B8668, 0x4A16476C, 0x93300461, 0x242DC565,
+    0xE94B9B11, 0x5E565A15, 0x87701918, 0x306DD81C,
+    0x353D9F02, 0x82205E06, 0x5B061D0B, 0xEC1BDC0F,
+    0x51A69337, 0xE6BB5233, 0x3F9D113E, 0x8880D03A,
+    0x8DD09724, 0x3ACD5620, 0xE3EB152D, 0x54F6D429,
+    0x7926A9C5, 0xCE3B68C1, 0x171D2BCC, 0xA000EAC8,
+    0xA550ADD6, 0x124D6CD2, 0xCB6B2FDF, 0x7C76EEDB,
+    0xC1CBA1E3, 0x76D660E7, 0xAFF023EA, 0x18EDE2EE,
+    0x1DBDA5F0, 0xAAA064F4, 0x738627F9, 0xC49BE6FD,
+    0x09FDB889, 0xBEE0798D, 0x67C63A80, 0xD0DBFB84,
+    0xD58BBC9A, 0x62967D9E, 0xBBB03E93, 0x0CADFF97,
+    0xB110B0AF, 0x060D71AB, 0xDF2B32A6, 0x6836F3A2,
+    0x6D66B4BC, 0xDA7B75B8, 0x035D36B5, 0xB440F7B1,
+];
+
+/// BZip2-specific CRC-32 calculator.
+pub(super) struct Crc {
+    value: u32,
+}
+
+impl Crc {
+    pub(super) fn new() -> Self {
+        Self { value: 0 }
+    }
+
+    /// Reset the CRC state ready for a new block.
+    pub(super) fn initialise(&mut self) {
+        self.value = 0xFFFF_FFFF;
+    }
+
+    /// Return the final CRC value for the current block.
+    ///
+    /// Byte-swaps before inverting to match the bzip2 big-endian CRC format.
+    pub(super) fn get_final(&self) -> u32 {
+        !self.value.swap_bytes()
+    }
+
+    /// Update the CRC with a single byte.
+    pub(super) fn update(&mut self, ch: u8) {
+        self.value = (self.value >> 8) ^ CRC32_TABLE[(self.value as u8 ^ ch) as usize];
+    }
+
+    /// Update the CRC with `run_length` repetitions of the same byte.
+    ///
+    /// Processes four bytes at a time for efficiency. `run_length` must be >= 4.
+    pub(super) fn update_run(&mut self, ch: u8, mut run_length: usize) {
+        debug_assert!(run_length >= 4);
+
+        let ch2 = (ch as u32) << 8 | ch as u32;
+        let ch4 = ch2 << 16 | ch2;
+
+        loop {
+            self.value ^= ch4;
+            self.value = (self.value >> 8) ^ CRC32_TABLE[self.value as u8 as usize];
+            self.value = (self.value >> 8) ^ CRC32_TABLE[self.value as u8 as usize];
+            self.value = (self.value >> 8) ^ CRC32_TABLE[self.value as u8 as usize];
+            self.value = (self.value >> 8) ^ CRC32_TABLE[self.value as u8 as usize];
+
+            run_length -= 4;
+            if run_length < 4 {
+                break;
+            }
+        }
+
+        match run_length & 3 {
+            1 => self.update(ch),
+            2 => { self.update(ch); self.update(ch); }
+            3 => { self.update(ch); self.update(ch); self.update(ch); }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn crc_of(data: &[u8]) -> u32 {
+        let mut crc = Crc::new();
+        crc.initialise();
+        for &b in data {
+            crc.update(b);
+        }
+        crc.get_final()
+    }
+
+    /// `update_run(ch, n)` must produce the same CRC as n individual `update(ch)` calls.
+    #[test]
+    fn update_run_matches_update() {
+        for &len in &[4usize, 5, 7, 8, 9, 15, 16, 100] {
+            let ch = 0xA5u8;
+
+            let mut by_update = Crc::new();
+            by_update.initialise();
+            for _ in 0..len {
+                by_update.update(ch);
+            }
+
+            let mut by_run = Crc::new();
+            by_run.initialise();
+            by_run.update_run(ch, len);
+
+            assert_eq!(
+                by_update.get_final(), by_run.get_final(),
+                "mismatch for run_length = {len}"
+            );
+        }
+    }
+
+    /// CRC of the same data computed two different ways must agree.
+    #[test]
+    fn update_then_run_consistent() {
+        // prefix "AB" then a run of 0xFF × 8
+        let mut c1 = Crc::new();
+        c1.initialise();
+        c1.update(b'A');
+        c1.update(b'B');
+        for _ in 0..8 { c1.update(0xFF); }
+
+        let mut c2 = Crc::new();
+        c2.initialise();
+        c2.update(b'A');
+        c2.update(b'B');
+        c2.update_run(0xFF, 8);
+
+        assert_eq!(c1.get_final(), c2.get_final());
+    }
+
+    /// Two different byte sequences must produce different CRC values (collision
+    /// sanity check — not a proof of correctness, but catches obvious bugs).
+    #[test]
+    fn different_data_different_crc() {
+        assert_ne!(crc_of(b"hello"), crc_of(b"world"));
+        assert_ne!(crc_of(b"abc"),   crc_of(b"abd"));
+        assert_ne!(crc_of(b""),      crc_of(b"\x00"));
+    }
+
+    /// CRC must change when byte order changes.
+    #[test]
+    fn crc_is_order_sensitive() {
+        assert_ne!(crc_of(b"\x01\x02"), crc_of(b"\x02\x01"));
+    }
+}

--- a/src/util/bzip2/mod.rs
+++ b/src/util/bzip2/mod.rs
@@ -21,16 +21,46 @@
 //!
 //! Port of `util/bzip2/` from bc-csharp.
 //!
+//! ## Example
+//!
+//! ```rust
+//! use std::io::{Read, Write};
+//! use bc_rust::util::bzip2::{BZip2Reader, BZip2Writer};
+//!
+//! // Compress
+//! let mut compressed = Vec::new();
+//! {
+//!     let mut writer = BZip2Writer::new(&mut compressed).unwrap();
+//!     writer.write_all(b"Hello, world!").unwrap();
+//!     writer.finish().unwrap();
+//! }
+//!
+//! // Decompress
+//! let mut reader = BZip2Reader::new(compressed.as_slice()).unwrap();
+//! let mut output = Vec::new();
+//! reader.read_to_end(&mut output).unwrap();
+//!
+//! assert_eq!(output, b"Hello, world!");
+//! ```
+//!
+//! ## Public API
+//!
+//! | Type | Description |
+//! |------|-------------|
+//! | [`BZip2Reader`] | Decompression — wraps any [`std::io::Read`] |
+//! | [`BZip2Writer`] | Compression — wraps any [`std::io::Write`] |
+//!
 //! ## bc-csharp mapping
 //!
-//! | bc-csharp | bc-rust | Notes |
-//! |-----------|---------|-------|
-//! | `BZip2Constants.cs` | [`constants`] | Shared constants |
-//! | `CRC.cs` | [`crc`] | CRC-32 calculation |
-//! | `CBZip2InputStream.cs` | [`bzip2_reader`] | Decompression reader |
-//! | `CBZip2OutputStream.cs` | [`bzip2_writer`] | Compression writer |
+//! | bc-csharp | bc-rust |
+//! |-----------|---------|
+//! | `CBZip2InputStream.cs` | [`BZip2Reader`] |
+//! | `CBZip2OutputStream.cs` | [`BZip2Writer`] |
 
-pub mod bzip2_reader;
-pub mod bzip2_writer;
+pub(super) mod bzip2_reader;
+pub(super) mod bzip2_writer;
 pub(super) mod constants;
 pub(super) mod crc;
+
+pub use bzip2_reader::BZip2Reader;
+pub use bzip2_writer::BZip2Writer;

--- a/src/util/bzip2/mod.rs
+++ b/src/util/bzip2/mod.rs
@@ -1,0 +1,36 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License. You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This package is based on the work done by Keiron Liddle, Aftex Software
+// <keiron@aftexsw.com> to whom the Ant project is very grateful for his
+// great code.
+
+//! BZip2 compression and decompression.
+//!
+//! Port of `util/bzip2/` from bc-csharp.
+//!
+//! ## bc-csharp mapping
+//!
+//! | bc-csharp | bc-rust | Notes |
+//! |-----------|---------|-------|
+//! | `BZip2Constants.cs` | [`constants`] | Shared constants |
+//! | `CRC.cs` | [`crc`] | CRC-32 calculation |
+//! | `CBZip2InputStream.cs` | [`bzip2_reader`] | Decompression reader |
+//! | `CBZip2OutputStream.cs` | [`bzip2_writer`] | Compression writer |
+
+pub mod bzip2_reader;
+pub mod bzip2_writer;
+pub(super) mod constants;
+pub(super) mod crc;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,8 +10,10 @@
 //! | `util/Integers.cs` | [`integers`] | Bit manipulation for `u32` |
 //! | `util/Longs.cs` | [`longs`] | Bit manipulation for `u64` |
 //! | `util/Shorts.cs` | [`shorts`] | Bit manipulation for `u16` |
+//! | `util/bzip2/` | [`bzip2`] | BZip2 compression and decompression |
 //! | `util/net/IPAddress.cs` | — | Not ported — covered by Rust `std::net` |
 
+pub mod bzip2;
 pub mod date;
 pub mod encoders;
 pub mod io;


### PR DESCRIPTION
## Changes

Implements full BZip2 codec support with compression and decompression capabilities.

### New Files
- `src/util/bzip2/mod.rs` - Module exports and public API
- `src/util/bzip2/bzip2_reader.rs` - Decompression implementation (~1025 lines)
- `src/util/bzip2/bzip2_writer.rs` - Compression implementation (~1484 lines)
- `src/util/bzip2/constants.rs` - BZip2 format constants and lookup tables
- `src/util/bzip2/crc.rs` - CRC32 checksum utilities for BZip2
- `CLAUDE.md` - Documentation for the implementation

### Modified Files
- `src/util/mod.rs` - Integrated BZip2 module into util namespace

### Implementation Details
- Full support for BZip2 compression and decompression
- CRC32 checksum validation
- Proper block handling and Huffman decoding
- Clippy warning fixes applied